### PR TITLE
refactor: change output_dir to .github with type-based subdirectories

### DIFF
--- a/.gaji.toml
+++ b/.gaji.toml
@@ -1,6 +1,6 @@
 [project]
 workflows_dir = "workflows"
-output_dir = ".github/workflows"
+output_dir = ".github"
 generated_dir = "generated"
 
 [watch]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -160,14 +160,14 @@ impl WorkflowBuilder {
             let out_dir = if build_output.output_type == "action" {
                 let action_dir = self
                     .output_dir
-                    .parent()
-                    .unwrap_or(Path::new("."))
                     .join("actions")
                     .join(&build_output.id);
                 fs::create_dir_all(&action_dir).await?;
                 action_dir
             } else {
-                self.output_dir.clone()
+                let workflows_dir = self.output_dir.join("workflows");
+                fs::create_dir_all(&workflows_dir).await?;
+                workflows_dir
             };
 
             // Determine output filename

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,7 +49,7 @@ pub enum Commands {
         input: String,
 
         /// Output directory for YAML files
-        #[arg(short, long, default_value = ".github/workflows")]
+        #[arg(short, long, default_value = ".github")]
         output: String,
 
         /// Preview YAML output without writing files

--- a/src/config.rs
+++ b/src/config.rs
@@ -94,7 +94,7 @@ fn default_workflows_dir() -> String {
 }
 
 fn default_output_dir() -> String {
-    ".github/workflows".to_string()
+    ".github".to_string()
 }
 
 fn default_generated_dir() -> String {
@@ -191,7 +191,7 @@ mod tests {
     fn test_default_config() {
         let config = Config::default();
         assert_eq!(config.project.workflows_dir, "workflows");
-        assert_eq!(config.project.output_dir, ".github/workflows");
+        assert_eq!(config.project.output_dir, ".github");
         assert_eq!(config.project.generated_dir, "generated");
         assert_eq!(config.watch.debounce_ms, 300);
         assert!(config.build.validate);
@@ -235,7 +235,7 @@ workflows_dir = "my_workflows"
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.project.workflows_dir, "my_workflows");
         // Other fields should use defaults
-        assert_eq!(config.project.output_dir, ".github/workflows");
+        assert_eq!(config.project.output_dir, ".github");
         assert_eq!(config.project.generated_dir, "generated");
         assert_eq!(config.watch.debounce_ms, 300);
         assert!(config.build.validate);


### PR DESCRIPTION
Previously, output_dir defaulted to .github/workflows, but composite actions used .github/actions via parent directory traversal. This created inconsistency between the configured output_dir and actual output locations. Now output_dir defaults to .github, and both workflows and actions are automatically placed in their respective subdirectories (.github/workflows and .github/actions) based on type.