### PR TITLE
feat: add build timing, progress bars, and cache TTL

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -4,7 +4,7 @@ Type-safe GitHub Actions workflows in TypeScript
 
 ---
 
-## Current Status (v0.2.7)
+## Current Status (v0.2.8)
 
 gaji is a working CLI tool with all core features implemented. It is self-dogfooding (uses itself for its own CI/CD workflows) and has been released on both crates.io and npm.
 
@@ -16,8 +16,9 @@ gaji is a working CLI tool with all core features implemented. It is self-dogfoo
 - npm distribution with platform-specific binary packages
 - CI/CD automation via release-plz
 - VitePress documentation site with English/Korean i18n (https://gaji.gaebalgom.work)
-- 93 tests (90 unit + 3 integration)
+- 95 tests (92 unit + 3 integration)
 - JavaScriptAction class for node-based GitHub Actions
+- npx support for running without installation
 
 ---
 
@@ -53,15 +54,21 @@ gaji is a working CLI tool with all core features implemented. It is self-dogfoo
 
 ---
 
+## In Progress (v0.3.0)
+
+### Easy Wins — Polish & UX
+- [x] Execution time measurement for builds (`Instant` timer in build pipeline)
+- [x] Progress indicators with `indicatif` (action download, type generation)
+- [x] Cache expiration policy (enforce `is_expired()` with configurable TTL via `build.cache_ttl_days`)
+
+---
+
 ## Remaining Work
 
 ### Polish & Quality
 - [ ] Parallel action.yml downloads (futures::stream::buffer_unordered)
 - [ ] Memory/LRU cache for action metadata
-- [ ] Cache expiration policy (auto re-validate after N days)
 - [ ] Better error messages with suggestions ("Did you mean...?")
-- [ ] Improved progress indicators (indicatif)
-- [ ] Execution time measurement for builds
 - [ ] YAML lint rules and warnings (unnamed jobs, unknown fields)
 - [ ] Template literal support in `getAction()` calls
 - [ ] Respect `.gitignore` patterns when scanning
@@ -90,6 +97,7 @@ gaji is a working CLI tool with all core features implemented. It is self-dogfoo
 
 | Version | Date | Highlights |
 |---------|------|------------|
+| v0.2.8 | 2026-02-13 | npx support |
 | v0.2.7 | 2026-02-13 | JavaScriptAction class |
 | v0.2.6 | 2026-02-13 | Documentation site, expression escaping fix |
 | v0.2.5 | 2026-02-12 | Output directory restructuring |

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,6 +49,9 @@ pub struct BuildConfig {
 
     #[serde(default = "default_true")]
     pub format: bool,
+
+    #[serde(default = "default_cache_ttl_days")]
+    pub cache_ttl_days: u64,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
@@ -85,6 +88,7 @@ impl Default for BuildConfig {
         Self {
             validate: true,
             format: true,
+            cache_ttl_days: default_cache_ttl_days(),
         }
     }
 }
@@ -103,6 +107,10 @@ fn default_generated_dir() -> String {
 
 fn default_debounce_ms() -> u64 {
     300
+}
+
+fn default_cache_ttl_days() -> u64 {
+    30
 }
 
 fn default_true() -> bool {
@@ -195,6 +203,7 @@ mod tests {
         assert_eq!(config.project.generated_dir, "generated");
         assert_eq!(config.watch.debounce_ms, 300);
         assert!(config.build.validate);
+        assert_eq!(config.build.cache_ttl_days, 30);
     }
 
     #[test]

--- a/src/watcher.rs
+++ b/src/watcher.rs
@@ -105,8 +105,13 @@ async fn handle_event(event: &Event) -> Result<()> {
         let token = gaji_config.resolve_token();
         let api_url = gaji_config.resolve_api_url();
         let cache = Cache::load_or_create()?;
-        let generator =
-            TypeGenerator::new(cache, std::path::PathBuf::from("generated"), token, api_url);
+        let generator = TypeGenerator::with_cache_ttl(
+            cache,
+            std::path::PathBuf::from("generated"),
+            token,
+            api_url,
+            gaji_config.build.cache_ttl_days,
+        );
 
         let new_refs: std::collections::HashSet<String> = action_refs
             .into_iter()


### PR DESCRIPTION
## Summary
- Add execution time measurement (`Instant` timer) to `build`, `dev`, and `add` commands
- Add `indicatif` progress bars to workflow builds and type generation loops
- Enforce cache TTL expiration via `build.cache_ttl_days` config (default 30 days)
- Add 3 new unit tests for cache expiration (95 total: 92 unit + 3 integration)
- Update ROADMAP.md to reflect v0.2.8 status and mark easy wins as completed

## Test plan
- [x] `cargo test --all-features` — 95 tests pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` — no warnings
- [x] `cargo fmt --all --check` — formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)