### PR TITLE
chore: release v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0](https://github.com/dodok8/gaji/compare/v0.2.8...v0.3.0) - 2026-02-13
+
+### Added
+
+- add build timing, progress bars, and cache expiration policy ([#32](https://github.com/dodok8/gaji/pull/32))
+
+### Other
+
+- change npx
+
 ## [0.2.8](https://github.com/dodok8/gaji/compare/v0.2.7...v0.2.8) - 2026-02-13
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "gaji"
-version = "0.2.8"
+version = "0.3.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaji"
-version = "0.2.8"
+version = "0.3.0"
 edition = "2021"
 description = "Type-safe GitHub Actions workflows in TypeScript"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `gaji`: 0.2.8 -> 0.3.0 (⚠ API breaking changes)

### ⚠ `gaji` breaking changes

```text
--- failure constructible_struct_adds_field: externally-constructible struct adds field ---

Description:
A pub struct constructible with a struct literal has a new pub field. Existing struct literals must be updated to include the new field.
        ref: https://doc.rust-lang.org/reference/expressions/struct-expr.html
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/constructible_struct_adds_field.ron

Failed in:
  field BuildConfig.cache_ttl_days in /tmp/.tmppGE3VR/gaji/src/config.rs:54

--- failure method_parameter_count_changed: pub method parameter count changed ---

Description:
A publicly-visible method now takes a different number of parameters, not counting the receiver (self) parameter.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#fn-change-arity
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/method_parameter_count_changed.ron

Failed in:
  gaji::fetcher::GitHubFetcher::new now takes 4 parameters instead of 3, in /tmp/.tmppGE3VR/gaji/src/fetcher.rs:167
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.0](https://github.com/dodok8/gaji/compare/v0.2.8...v0.3.0) - 2026-02-13

### Added

- add build timing, progress bars, and cache expiration policy ([#32](https://github.com/dodok8/gaji/pull/32))

### Other

- change npx
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).