### PR TITLE
chore: release v0.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1](https://github.com/dodok8/gaji/compare/v0.3.0...v0.3.1) - 2026-02-13
+
+### Added
+
+- add CompositeJob class and fill documentation gaps ([#35](https://github.com/dodok8/gaji/pull/35))
+
+### Other
+
+- update ROADMAP
+
 ## [0.3.0](https://github.com/dodok8/gaji/compare/v0.2.8...v0.3.0) - 2026-02-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "gaji"
-version = "0.3.0"
+version = "0.3.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaji"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 description = "Type-safe GitHub Actions workflows in TypeScript"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `gaji`: 0.3.0 -> 0.3.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.1](https://github.com/dodok8/gaji/compare/v0.3.0...v0.3.1) - 2026-02-13

### Added

- add CompositeJob class and fill documentation gaps ([#35](https://github.com/dodok8/gaji/pull/35))

### Other

- update ROADMAP
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).