### PR TITLE
chore: release v0.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2](https://github.com/dodok8/gaji/compare/v0.3.1...v0.3.2) - 2026-02-14
+
+### Other
+
+- add twoslash hover-to-show-type and document known limitations ([#36](https://github.com/dodok8/gaji/pull/36))
+
 ## [0.3.1](https://github.com/dodok8/gaji/compare/v0.3.0...v0.3.1) - 2026-02-13
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -592,7 +592,7 @@ dependencies = [
 
 [[package]]
 name = "gaji"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaji"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2021"
 description = "Type-safe GitHub Actions workflows in TypeScript"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `gaji`: 0.3.1 -> 0.3.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.2](https://github.com/dodok8/gaji/compare/v0.3.1...v0.3.2) - 2026-02-14

### Other

- add twoslash hover-to-show-type and document known limitations ([#36](https://github.com/dodok8/gaji/pull/36))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).