### PR TITLE
chore: release v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0](https://github.com/dodok8/gaji/compare/v0.3.2...v0.4.0) - 2026-02-14
+
+### Added
+
+- enhance CLI with completions, suggestions, and interactive init ([#38](https://github.com/dodok8/gaji/pull/38))
+
 ## [0.3.2](https://github.com/dodok8/gaji/compare/v0.3.1...v0.3.2) - 2026-02-14
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -601,7 +601,7 @@ dependencies = [
 
 [[package]]
 name = "gaji"
-version = "0.3.2"
+version = "0.4.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaji"
-version = "0.3.2"
+version = "0.4.0"
 edition = "2021"
 description = "Type-safe GitHub Actions workflows in TypeScript"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `gaji`: 0.3.2 -> 0.4.0 (⚠ API breaking changes)

### ⚠ `gaji` breaking changes

```text
--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Commands:Completions in /tmp/.tmpnAW2Hy/gaji/src/cli.rs:74
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.0](https://github.com/dodok8/gaji/compare/v0.3.2...v0.4.0) - 2026-02-14

### Added

- enhance CLI with completions, suggestions, and interactive init ([#38](https://github.com/dodok8/gaji/pull/38))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).