### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/dodok8/gaji/compare/v0.4.2...v0.4.3) - 2026-02-14
+
+### Added
+
+- action migration (action.yml → TypeScript) ([#45](https://github.com/dodok8/gaji/pull/45))
+
 ## [0.4.2](https://github.com/dodok8/gaji/compare/v0.4.1...v0.4.2) - 2026-02-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "gaji"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaji"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2021"
 description = "Type-safe GitHub Actions workflows in TypeScript"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `gaji`: 0.4.2 -> 0.4.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.3](https://github.com/dodok8/gaji/compare/v0.4.2...v0.4.3) - 2026-02-14

### Added

- action migration (action.yml → TypeScript) ([#45](https://github.com/dodok8/gaji/pull/45))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).