### PR TITLE
chore: release v0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0](https://github.com/dodok8/gaji/compare/v0.4.4...v0.5.0) - 2026-02-16
+
+### Added
+
+- unify dev/build CLI input flags to -i/--input ([#52](https://github.com/dodok8/gaji/pull/52))
+- add typed step outputs and job output passing ([#50](https://github.com/dodok8/gaji/pull/50))
+
 ## [0.4.4](https://github.com/dodok8/gaji/compare/v0.4.3...v0.4.4) - 2026-02-15
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "gaji"
-version = "0.4.4"
+version = "0.5.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaji"
-version = "0.4.4"
+version = "0.5.0"
 edition = "2021"
 description = "Type-safe GitHub Actions workflows in TypeScript"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `gaji`: 0.4.4 -> 0.5.0 (⚠ API breaking changes)

### ⚠ `gaji` breaking changes

```text
--- failure enum_struct_variant_field_added: pub enum struct variant field added ---

Description:
An enum's exhaustive struct variant has a new field, which has to be included when constructing or matching on this variant.
        ref: https://doc.rust-lang.org/reference/attributes/type_system.html#the-non_exhaustive-attribute
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_field_added.ron

Failed in:
  field input of variant Commands::Dev in /tmp/.tmpZxn3vg/gaji/src/cli.rs:38

--- failure enum_struct_variant_field_missing: pub enum struct variant's field removed or renamed ---

Description:
A publicly-visible enum has a struct variant whose field is no longer available under its prior name. It may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_struct_variant_field_missing.ron

Failed in:
  field dir of variant Commands::Dev, previously in file /tmp/.tmpM8LD88/gaji/src/cli.rs:38

--- failure function_missing: pub fn removed or renamed ---

Description:
A publicly-visible function cannot be imported by its prior path. A `pub use` may have been removed, or the function itself may have been renamed or removed entirely.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/function_missing.ron

Failed in:
  function gaji::watcher::watch_directory, previously in file /tmp/.tmpM8LD88/gaji/src/watcher.rs:16

--- failure pub_module_level_const_missing: pub module-level const is missing ---

Description:
A public const is missing or renamed
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#item-remove
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/pub_module_level_const_missing.ron

Failed in:
  GET_ACTION_RUNTIME_IMPL_TEMPLATE in file /tmp/.tmpM8LD88/gaji/src/generator/templates.rs:206
  GET_ACTION_BASE_RUNTIME_TEMPLATE in file /tmp/.tmpM8LD88/gaji/src/generator/templates.rs:193
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.0](https://github.com/dodok8/gaji/compare/v0.4.4...v0.5.0) - 2026-02-16

### Added

- unify dev/build CLI input flags to -i/--input ([#52](https://github.com/dodok8/gaji/pull/52))
- add typed step outputs and job output passing ([#50](https://github.com/dodok8/gaji/pull/50))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).