### PR TITLE
chore: release v0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.1](https://github.com/dodok8/gaji/compare/v0.5.0...v0.5.1) - 2026-02-19
+
+### Added
+
+- use config-based defaults for dev/build input and output paths ([#55](https://github.com/dodok8/gaji/pull/55))
+
+### Other
+
+- remove duplicated ([#56](https://github.com/dodok8/gaji/pull/56))
+- apply v-pre
+
 ## [0.5.0](https://github.com/dodok8/gaji/compare/v0.4.4...v0.5.0) - 2026-02-16
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "gaji"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaji"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Type-safe GitHub Actions workflows in TypeScript"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `gaji`: 0.5.0 -> 0.5.1 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.5.1](https://github.com/dodok8/gaji/compare/v0.5.0...v0.5.1) - 2026-02-19

### Added

- use config-based defaults for dev/build input and output paths ([#55](https://github.com/dodok8/gaji/pull/55))

### Other

- remove duplicated ([#56](https://github.com/dodok8/gaji/pull/56))
- apply v-pre
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).