### PR TITLE
chore: release v0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0](https://github.com/dodok8/gaji/compare/v0.5.1...v0.6.0) - 2026-02-20
+
+### Added
+
+- add `list` subcommand to show used GitHub Actions ([#58](https://github.com/dodok8/gaji/pull/58))
+
+### Other
+
+- Update ROADMAP
+- replace ROADMAP with gaji 1.0 plan ([#57](https://github.com/dodok8/gaji/pull/57))
+
 ## [0.5.1](https://github.com/dodok8/gaji/compare/v0.5.0...v0.5.1) - 2026-02-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "gaji"
-version = "0.5.1"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaji"
-version = "0.5.1"
+version = "0.6.0"
 edition = "2021"
 description = "Type-safe GitHub Actions workflows in TypeScript"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `gaji`: 0.5.1 -> 0.6.0 (⚠ API breaking changes)

### ⚠ `gaji` breaking changes

```text
--- failure enum_no_repr_variant_discriminant_changed: enum variant had its discriminant change value ---

Description:
The enum's variant had its discriminant value change. This breaks downstream code that used its value via a numeric cast like `as isize`.
        ref: https://doc.rust-lang.org/reference/items/enumerations.html#assigning-discriminant-values
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_no_repr_variant_discriminant_changed.ron

Failed in:
  variant Commands::Add 3 -> 4 in /tmp/.tmpy5LivN/gaji/src/cli.rs:72
  variant Commands::Clean 4 -> 5 in /tmp/.tmpy5LivN/gaji/src/cli.rs:78
  variant Commands::Completions 5 -> 6 in /tmp/.tmpy5LivN/gaji/src/cli.rs:85

--- failure enum_variant_added: enum variant added on exhaustive enum ---

Description:
A publicly-visible enum without #[non_exhaustive] has a new variant.
        ref: https://doc.rust-lang.org/cargo/reference/semver.html#enum-variant-new
       impl: https://github.com/obi1kenobi/cargo-semver-checks/tree/v0.46.0/src/lints/enum_variant_added.ron

Failed in:
  variant Commands:List in /tmp/.tmpy5LivN/gaji/src/cli.rs:61
```

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.6.0](https://github.com/dodok8/gaji/compare/v0.5.1...v0.6.0) - 2026-02-20

### Added

- add `list` subcommand to show used GitHub Actions ([#58](https://github.com/dodok8/gaji/pull/58))

### Other

- Update ROADMAP
- replace ROADMAP with gaji 1.0 plan ([#57](https://github.com/dodok8/gaji/pull/57))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).