### PR TITLE
refactor: Phase 3 — TS config, integration tests, and doc updates

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -694,9 +694,9 @@ Each file is independent:
 - ~~`defineConfig` declaration in `CLASS_DECLARATIONS_TEMPLATE`~~
 - ~~`defineConfig` runtime in `JOB_WORKFLOW_RUNTIME_TEMPLATE`~~
 
-### Phase 3 — Depends on Phase 2 (all parallel) ⬜ 미착수
+### ~~Phase 3 — Depends on Phase 2 (all parallel)~~ ✅
 
-Each group touches different files. All depend on Phase 2 for the new type/runtime shapes.
+~~Each group touches different files. All depend on Phase 2 for the new type/runtime shapes.~~
 
 #### ~~3A. `src/generator/mod.rs` — getAction overloads + type renames~~ ✅
 
@@ -705,41 +705,39 @@ Each group touches different files. All depend on Phase 2 for the new type/runti
 - ~~`GajiConfig` added to imports/re-exports~~
 - ~~Comment updated~~
 
-#### 3B. `tests/integration.rs` — New tests (moderate)
+#### ~~3B. `tests/integration.rs` — New tests (moderate)~~ ✅
 
-- Add `test_step_builder_callback_context`: `steps()` builder callback receives previous step outputs via `output` parameter
-- Add `test_outputs_callback_context`: `outputs()` callback receives previous step outputs via `output` parameter
-- Add `test_job_builder_callback_context`: `jobs()` builder callback receives previous job outputs via `output` parameter (replaces `jobOutputs` pattern)
+- ~~Add `test_step_builder_callback_context`: `steps()` builder callback receives previous step outputs via `output` parameter~~
+- ~~Add `test_outputs_callback_context`: `outputs()` callback receives previous step outputs via `output` parameter~~
+- ~~Add `test_job_builder_callback_context`: `jobs()` builder callback receives previous job outputs via `output` parameter (replaces `jobOutputs` pattern)~~
 
-#### 3C. `src/init/templates.rs` — EXAMPLE_WORKFLOW_TEMPLATE (easy)
+#### ~~3C. `src/init/templates.rs` — EXAMPLE_WORKFLOW_TEMPLATE (easy)~~ ✅
 
-- Update to use `steps(s => s.add(...))` and `jobs(j => j.add(...))` patterns
+- ~~Update to use `steps(s => s.add(...))` and `jobs(j => j.add(...))` patterns~~
 
-#### 3D. `CLAUDE.md` — Project documentation (easy)
+#### ~~3D. `CLAUDE.md` — Project documentation (easy)~~ ✅
 
-- Update "Key Design Patterns" section: remove `CompositeJob`, rename classes
-- Update "Runtime Class Hierarchy" table: apply renames, remove CompositeJob
-- Update "Adding a new action type" and "Adding a new job type" sections
-- Update "Configuration Files" table: `.gaji.toml` → `gaji.config.ts`, `.gaji.local.toml` → `gaji.config.local.ts`
-- Update "Configuration hierarchy" line: `env vars > gaji.config.local.ts > gaji.config.ts > defaults`
+- ~~Update "Key Design Patterns" section: remove `CompositeJob`, rename classes~~
+- ~~Update "Runtime Class Hierarchy" table: apply renames, remove CompositeJob~~
+- ~~Update "Adding a new action type" and "Adding a new job type" sections~~
+- ~~Update "Configuration Files" table: `.gaji.toml` → `gaji.config.ts`, `.gaji.local.toml` → `gaji.config.local.ts`~~
+- ~~Update "Configuration hierarchy" line: `env vars > gaji.config.local.ts > gaji.config.ts > defaults`~~
 
-#### 3E. `src/config.rs` — Replace TOML loading with TS execution (moderate) ★
+#### ~~3E. `src/config.rs` — Replace TOML loading with TS execution (moderate) ★~~ ✅
 
-- Remove `toml` dependency for config loading
-- Add `load_from_ts()` that:
-  1. Checks for `gaji.config.ts` (falls back to `.gaji.toml` for backward compat)
-  2. Strips types with oxc
-  3. Executes in QuickJS with a wrapper that captures `export default`
-  4. Deserializes JSON result into `Config` struct
-- Add `merge_local_ts()` for `gaji.config.local.ts`
-- Keep field mapping: `workflows` → `workflows_dir`, `output` → `output_dir`, `generated` → `generated_dir`, `watch.debounce` → `watch.debounce_ms`, `build.cacheTtlDays` → `build.cache_ttl_days`
-- Keep `resolve_token()` priority: env var > local config > config > None
+- ~~Add `TsGajiConfig` intermediate struct with camelCase JSON deserialization~~
+- ~~Add `load_from_ts()` that strips types, executes in QuickJS, deserializes JSON~~
+- ~~`Config::load()` tries `gaji.config.ts` first, falls back to `.gaji.toml`~~
+- ~~Removed `save()`, `save_to()`, and `Serialize` derives~~
+- ~~Added 3 config tests: basic, with local, empty config~~
 
-#### 3F. `src/init/mod.rs` + `src/init/templates.rs` — Generate TS config (moderate)
+#### ~~3F. `src/init/mod.rs` + `src/init/templates.rs` — Generate TS config (moderate)~~ ✅
 
-- `gaji init` generates `gaji.config.ts` instead of `.gaji.toml`
-- Add `GAJI_CONFIG_TEMPLATE` constant for default `gaji.config.ts` content
-- Update `.gitignore` template: replace `.gaji.local.toml` with `gaji.config.local.ts`
+- ~~`gaji init` generates `gaji.config.ts` instead of `.gaji.toml`~~
+- ~~Added `GAJI_CONFIG_TEMPLATE` constant for default `gaji.config.ts` content~~
+- ~~Updated `.gitignore` template: `.gaji.local.toml` → `gaji.config.local.ts`~~
+- ~~Updated `print_next_steps()` with TS config example~~
+- ~~Updated interactive init to write TS config directly~~
 
 ### Phase 4 — Depends on Phase 3 (all parallel) ⬜ 미착수
 

--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -1,74 +1,75 @@
 # Configuration
 
-gaji can be configured using a `.gaji.toml` file in your project root.
+gaji uses TypeScript configuration files for type-safe settings with autocomplete.
 
 ## Configuration File
 
-Create `.gaji.toml` in your project root. You can quickly generate one with `gaji init`.
+Create `gaji.config.ts` in your project root. `gaji init` generates one automatically.
 
-```toml
-[project]
-workflows_dir = "workflows"
-output_dir = ".github"
-generated_dir = "generated"
+```typescript
+import { defineConfig } from "./generated/index.js";
 
-[github]
-# Optional: GitHub token (can also use GITHUB_TOKEN env var)
-token = "ghp_your_token_here"
-# For GitHub Enterprise users
-api_url = "https://github.example.com"
-
-[watch]
-debounce_ms = 300
-ignored_patterns = ["node_modules", ".git", "generated"]
-
-[build]
-validate = true
-format = true
+export default defineConfig({
+    workflows: "workflows",
+    output: ".github",
+    generated: "generated",
+    watch: {
+        debounce: 300,
+        ignore: ["node_modules", ".git", "generated"],
+    },
+    build: {
+        validate: true,
+        format: true,
+    },
+});
 ```
+
+The `defineConfig` function provides autocomplete and type checking for all fields. At runtime it returns its argument unchanged.
 
 ## Configuration Options
 
-### `[project]`
-
-Project-level settings:
+### Project Directories
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `workflows_dir` | string | `"workflows"` | Directory containing TypeScript workflows. Used as the default `--input` for `gaji dev` and `gaji build` |
-| `output_dir` | string | `".github"` | Base output directory (workflows go to `workflows/`, actions to `actions/`). Used as the default `--output` for `gaji build` |
-| `generated_dir` | string | `"generated"` | Directory for generated action types |
+| `workflows` | string | `"workflows"` | Directory containing TypeScript workflows. Used as the default `--input` for `gaji dev` and `gaji build` |
+| `output` | string | `".github"` | Base output directory (workflows go to `workflows/`, actions to `actions/`). Used as the default `--output` for `gaji build` |
+| `generated` | string | `"generated"` | Directory for generated action types |
 
 **Example:**
 
-```toml
-[project]
-workflows_dir = "gha"
-output_dir = ".github"
-generated_dir = "gha-types"
+```typescript
+export default defineConfig({
+    workflows: "gha",
+    output: ".github",
+    generated: "gha-types",
+});
 ```
 
-### `[github]`
+### `github`
 
 GitHub API settings:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
 | `token` | string (optional) | None | GitHub personal access token |
-| `api_url` | string (optional) | `"https://github.com"` | GitHub base URL (for Enterprise) |
+| `apiUrl` | string (optional) | `"https://github.com"` | GitHub base URL (for Enterprise) |
 
 **Token Priority:**
 
 1. `GITHUB_TOKEN` environment variable (highest priority)
-2. `token` in `.gaji.local.toml`
-3. `token` in `.gaji.toml`
+2. `token` in `gaji.config.local.ts`
+3. `token` in `gaji.config.ts`
 
 **Example for GitHub Enterprise:**
 
-```toml
-[github]
-token = "ghp_your_token_here"
-api_url = "https://github.example.com"
+```typescript
+export default defineConfig({
+    github: {
+        token: "ghp_your_token_here",
+        apiUrl: "https://github.example.com",
+    },
+});
 ```
 
 **What you can configure:**
@@ -77,25 +78,28 @@ api_url = "https://github.example.com"
 - **GitHub Enterprise**: Point to your self-hosted GitHub instance
 - **Action fetching**: Retrieve `action.yml` from private or enterprise GitHub
 
-**Note:** For security, store tokens in `.gaji.local.toml` (gitignored) instead of `.gaji.toml`
+**Note:** For security, store tokens in `gaji.config.local.ts` (gitignored) instead of `gaji.config.ts`
 
-### `[watch]`
+### `watch`
 
 File watching settings:
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `debounce_ms` | integer | `300` | Debounce delay in milliseconds |
-| `ignored_patterns` | array | `["node_modules", ".git", "generated"]` | Patterns to ignore |
+| `debounce` | number | `300` | Debounce delay in milliseconds |
+| `ignore` | string[] | `["node_modules", ".git", "generated"]` | Patterns to ignore |
 
-The `ignored_patterns` setting is used by both `gaji dev` (watch mode) and `gaji build` commands. Files matching any of these patterns will be excluded from processing. The matching uses simple substring matching - if any pattern appears anywhere in the file path, the file is ignored.
+The `ignore` setting is used by both `gaji dev` (watch mode) and `gaji build` commands. Files matching any of these patterns will be excluded from processing. The matching uses simple substring matching - if any pattern appears anywhere in the file path, the file is ignored.
 
 **Example:**
 
-```toml
-[watch]
-debounce_ms = 500
-ignored_patterns = ["node_modules", ".git", "generated", "dist", "coverage"]
+```typescript
+export default defineConfig({
+    watch: {
+        debounce: 500,
+        ignore: ["node_modules", ".git", "generated", "dist", "coverage"],
+    },
+});
 ```
 
 **Common patterns to ignore:**
@@ -106,7 +110,7 @@ ignored_patterns = ["node_modules", ".git", "generated", "dist", "coverage"]
 - `dist` - build output directories
 - `coverage` - test coverage reports
 
-### `[build]`
+### `build`
 
 Build settings:
 
@@ -114,13 +118,33 @@ Build settings:
 |--------|------|---------|-------------|
 | `validate` | boolean | `true` | Validate generated YAML |
 | `format` | boolean | `true` | Format generated YAML |
+| `cacheTtlDays` | number | `30` | Cache TTL in days for action metadata |
 
 **Example:**
 
-```toml
-[build]
-validate = true
-format = true
+```typescript
+export default defineConfig({
+    build: {
+        validate: true,
+        format: true,
+        cacheTtlDays: 14,
+    },
+});
+```
+
+## Local Configuration
+
+Create `gaji.config.local.ts` for sensitive values like tokens. This file should be gitignored.
+
+```typescript
+import { defineConfig } from "./generated/index.js";
+
+export default defineConfig({
+    github: {
+        token: "ghp_your_token_here",
+        apiUrl: "https://github.example.com",
+    },
+});
 ```
 
 ## TypeScript Configuration
@@ -137,7 +161,7 @@ gaji works with standard TypeScript configuration. Make sure your `tsconfig.json
     "skipLibCheck": true,
     "typeRoots": [
       "./node_modules/@types",
-      "./generated"  // Include gaji-generated types
+      "./generated"
     ]
   },
   "include": ["workflows/**/*"],
@@ -153,9 +177,14 @@ Add gaji-generated files to your `.gitignore`:
 # gaji
 generated/
 .gaji-cache.json
+gaji.config.local.ts
 ```
 
 **Note:** Do NOT ignore `.github/workflows/` since those are the actual workflow files GitHub Actions uses.
+
+## Backward Compatibility
+
+gaji still reads `.gaji.toml` and `.gaji.local.toml` if `gaji.config.ts` is not found. Existing projects using TOML configuration continue to work without changes.
 
 ## Cache
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -63,37 +63,27 @@ import { getAction, Job, Workflow } from "../generated/index.js";
 const checkout = getAction("actions/checkout@v5");
 const setupNode = getAction("actions/setup-node@v4");
 
-// Define the build job
-const build = new Job("ubuntu-latest")
-  .addStep(checkout({
-    name: "Checkout code",
-  }))
-  .addStep(setupNode({
-    name: "Setup Node.js",
-    with: {
-      "node-version": "20",  // ✅ Autocomplete available!
-    },
-  }))
-  .addStep({
-    name: "Install dependencies",
-    run: "npm ci",
-  })
-  .addStep({
-    name: "Run tests",
-    run: "npm test",
-  });
-
-// Create the workflow
-const workflow = new Workflow({
+// Create the workflow with callback builder API
+new Workflow({
   name: "CI",
   on: {
     push: { branches: ["main"] },
     pull_request: { branches: ["main"] },
   },
-}).addJob("build", build);
-
-// Build the YAML file
-workflow.build("ci");
+}).jobs(j => j
+  .add("build",
+    new Job("ubuntu-latest")
+      .steps(s => s
+        .add(checkout({ name: "Checkout code" }))
+        .add(setupNode({
+          name: "Setup Node.js",
+          with: { "node-version": "20" },  // ✅ Autocomplete available!
+        }))
+        .add({ name: "Install dependencies", run: "npm ci" })
+        .add({ name: "Run tests", run: "npm test" })
+      )
+  )
+).build("ci");
 ```
 
 ## Generate Types and Build

--- a/docs/ko/guide/configuration.md
+++ b/docs/ko/guide/configuration.md
@@ -1,74 +1,75 @@
 # 설정
 
-프로젝트 루트에 `.gaji.toml` 파일을 사용하여 gaji를 설정할 수 있습니다.
+gaji는 TypeScript 설정 파일을 사용하여 자동완성이 되는 타입 안전한 설정을 지원합니다.
 
 ## 설정 파일
 
-프로젝트 루트에 `.gaji.toml` 생성합시다. `gaji init` 을 통해 빠르게 생성할 수 있습니다.
+프로젝트 루트에 `gaji.config.ts`를 생성합시다. `gaji init`을 통해 자동으로 생성할 수 있습니다.
 
-```toml
-[project]
-workflows_dir = "workflows"
-output_dir = ".github"
-generated_dir = "generated"
+```typescript
+import { defineConfig } from "./generated/index.js";
 
-[github]
-# 선택사항: GitHub 토큰 (GITHUB_TOKEN 환경 변수로도 설정 가능)
-token = "ghp_your_token_here"
-# GitHub Enterprise 사용자용
-api_url = "https://github.example.com"
-
-[watch]
-debounce_ms = 300
-ignored_patterns = ["node_modules", ".git", "generated"]
-
-[build]
-validate = true
-format = true
+export default defineConfig({
+    workflows: "workflows",
+    output: ".github",
+    generated: "generated",
+    watch: {
+        debounce: 300,
+        ignore: ["node_modules", ".git", "generated"],
+    },
+    build: {
+        validate: true,
+        format: true,
+    },
+});
 ```
+
+`defineConfig` 함수는 모든 필드에 대한 자동완성과 타입 검사를 제공합니다. 런타임에는 인자를 그대로 반환합니다.
 
 ## 설정 옵션
 
-### `[project]`
-
-프로젝트 수준 설정:
+### 프로젝트 디렉토리
 
 | 옵션 | 타입 | 기본값 | 설명 |
 |------|------|--------|------|
-| `workflows_dir` | string | `"workflows"` | TypeScript 워크플로우가 있는 디렉토리. `gaji dev`와 `gaji build`의 `--input` 기본값으로 사용 |
-| `output_dir` | string | `".github"` | 기본 출력 디렉토리 (워크플로우는 `workflows/`, 액션은 `actions/`에 저장). `gaji build`의 `--output` 기본값으로 사용 |
-| `generated_dir` | string | `"generated"` | 생성된 액션 타입용 디렉토리 |
+| `workflows` | string | `"workflows"` | TypeScript 워크플로우가 있는 디렉토리. `gaji dev`와 `gaji build`의 `--input` 기본값으로 사용 |
+| `output` | string | `".github"` | 기본 출력 디렉토리 (워크플로우는 `workflows/`, 액션은 `actions/`에 저장). `gaji build`의 `--output` 기본값으로 사용 |
+| `generated` | string | `"generated"` | 생성된 액션 타입용 디렉토리 |
 
 **예제:**
 
-```toml
-[project]
-workflows_dir = "gha"
-output_dir = ".github"
-generated_dir = "gha-types"
+```typescript
+export default defineConfig({
+    workflows: "gha",
+    output: ".github",
+    generated: "gha-types",
+});
 ```
 
-### `[github]`
+### `github`
 
 GitHub API 설정:
 
 | 옵션 | 타입 | 기본값 | 설명 |
 |------|------|--------|------|
 | `token` | string (선택) | None | GitHub 개인 액세스 토큰 |
-| `api_url` | string (선택) | `"https://github.com"` | GitHub 기본 URL (Enterprise용) |
+| `apiUrl` | string (선택) | `"https://github.com"` | GitHub 기본 URL (Enterprise용) |
 
 **토큰 우선순위:**
 
 1. `GITHUB_TOKEN` 환경 변수 (최우선)
-2. `.gaji.local.toml`의 `token`
-3. `.gaji.toml`의 `token`
+2. `gaji.config.local.ts`의 `token`
+3. `gaji.config.ts`의 `token`
 
 **GitHub Enterprise 예제:**
 
-```toml
-[github]
-token = "ghp_your_token_here"
-api_url = "https://github.example.com"
+```typescript
+export default defineConfig({
+    github: {
+        token: "ghp_your_token_here",
+        apiUrl: "https://github.example.com",
+    },
+});
 ```
 
 **설정 가능한 항목:**
@@ -77,25 +78,28 @@ api_url = "https://github.example.com"
 - **GitHub Enterprise**: 자체 호스팅 GitHub 인스턴스 지정
 - **액션 가져오기**: 프라이빗 또는 엔터프라이즈 GitHub에서 `action.yml` 가져오기
 
-**참고:** 보안을 위해 토큰은 `.gaji.toml` 대신 `.gaji.local.toml`(gitignored)에 저장하세요
+**참고:** 보안을 위해 토큰은 `gaji.config.ts` 대신 `gaji.config.local.ts`(gitignored)에 저장하세요
 
-### `[watch]`
+### `watch`
 
 파일 감시 설정:
 
 | 옵션 | 타입 | 기본값 | 설명 |
 |------|------|--------|------|
-| `debounce_ms` | integer | `300` | 밀리초 단위 디바운스 지연 |
-| `ignored_patterns` | array | `["node_modules", ".git", "generated"]` | 무시할 패턴 |
+| `debounce` | number | `300` | 밀리초 단위 디바운스 지연 |
+| `ignore` | string[] | `["node_modules", ".git", "generated"]` | 무시할 패턴 |
 
-`ignored_patterns` 설정은 `gaji dev` (watch 모드)와 `gaji build` 명령어 모두에서 사용됩니다. 이 패턴과 일치하는 파일은 처리에서 제외됩니다. 매칭은 단순 문자열 포함 여부로 판단됩니다 - 파일 경로에 패턴이 포함되어 있으면 해당 파일은 무시됩니다.
+`ignore` 설정은 `gaji dev` (watch 모드)와 `gaji build` 명령어 모두에서 사용됩니다. 이 패턴과 일치하는 파일은 처리에서 제외됩니다. 매칭은 단순 문자열 포함 여부로 판단됩니다 - 파일 경로에 패턴이 포함되어 있으면 해당 파일은 무시됩니다.
 
 **예제:**
 
-```toml
-[watch]
-debounce_ms = 500
-ignored_patterns = ["node_modules", ".git", "generated", "dist", "coverage"]
+```typescript
+export default defineConfig({
+    watch: {
+        debounce: 500,
+        ignore: ["node_modules", ".git", "generated", "dist", "coverage"],
+    },
+});
 ```
 
 **일반적으로 무시하는 패턴:**
@@ -106,7 +110,7 @@ ignored_patterns = ["node_modules", ".git", "generated", "dist", "coverage"]
 - `dist` - 빌드 출력 디렉토리
 - `coverage` - 테스트 커버리지 리포트
 
-### `[build]`
+### `build`
 
 빌드 설정:
 
@@ -114,13 +118,33 @@ ignored_patterns = ["node_modules", ".git", "generated", "dist", "coverage"]
 |------|------|--------|------|
 | `validate` | boolean | `true` | 생성된 YAML 검증 |
 | `format` | boolean | `true` | 생성된 YAML 포맷 |
+| `cacheTtlDays` | number | `30` | 액션 메타데이터 캐시 TTL (일 단위) |
 
 **예제:**
 
-```toml
-[build]
-validate = true
-format = true
+```typescript
+export default defineConfig({
+    build: {
+        validate: true,
+        format: true,
+        cacheTtlDays: 14,
+    },
+});
+```
+
+## 로컬 설정
+
+토큰 같은 민감한 값은 `gaji.config.local.ts`에 작성합시다. 이 파일은 gitignore에 추가해야 합니다.
+
+```typescript
+import { defineConfig } from "./generated/index.js";
+
+export default defineConfig({
+    github: {
+        token: "ghp_your_token_here",
+        apiUrl: "https://github.example.com",
+    },
+});
 ```
 
 ## TypeScript 설정
@@ -153,15 +177,20 @@ gaji가 생성한 파일을 `.gitignore`에 추가:
 # gaji
 generated/
 .gaji-cache.json
+gaji.config.local.ts
 ```
 
 **참고:** `.github/workflows/`는 무시하지 마세요. 이것은 GitHub Actions가 실제로 사용하는 워크플로우 파일입니다.
+
+## 하위 호환성
+
+`gaji.config.ts`가 없으면 gaji는 `.gaji.toml`과 `.gaji.local.toml`을 읽습니다. TOML 설정을 사용하는 기존 프로젝트는 변경 없이 계속 동작합니다.
 
 ## 캐시
 
 gaji는 액션 정의를 다시 가져오지 않도록 캐시 파일(`.gaji-cache.json`)을 사용합니다. 이 파일은 자동으로 관리되며 gitignore에 추가해야 합니다.
 
-캐시를 지우려면면 `clean` 명령어를 사용하세요.
+캐시를 지우려면 `clean` 명령어를 사용하세요.
 
 ```bash
 gaji clean --cache

--- a/docs/ko/guide/getting-started.md
+++ b/docs/ko/guide/getting-started.md
@@ -63,37 +63,27 @@ import { getAction, Job, Workflow } from "../generated/index.js";
 const checkout = getAction("actions/checkout@v5");
 const setupNode = getAction("actions/setup-node@v4");
 
-// 빌드 작업 정의
-const build = new Job("ubuntu-latest")
-  .addStep(checkout({
-    name: "Checkout code",
-  }))
-  .addStep(setupNode({
-    name: "Setup Node.js",
-    with: {
-      "node-version": "20",  // ✅ 자동완성 사용 가능!
-    },
-  }))
-  .addStep({
-    name: "Install dependencies",
-    run: "npm ci",
-  })
-  .addStep({
-    name: "Run tests",
-    run: "npm test",
-  });
-
-// 워크플로우 생성
-const workflow = new Workflow({
+// 콜백 빌더 API로 워크플로우 생성
+new Workflow({
   name: "CI",
   on: {
     push: { branches: ["main"] },
     pull_request: { branches: ["main"] },
   },
-}).addJob("build", build);
-
-// YAML 파일 빌드
-workflow.build("ci");
+}).jobs(j => j
+  .add("build",
+    new Job("ubuntu-latest")
+      .steps(s => s
+        .add(checkout({ name: "Checkout code" }))
+        .add(setupNode({
+          name: "Setup Node.js",
+          with: { "node-version": "20" },  // ✅ 자동완성 사용 가능!
+        }))
+        .add({ name: "Install dependencies", run: "npm ci" })
+        .add({ name: "Run tests", run: "npm test" })
+      )
+  )
+).build("ci");
 ```
 
 ## 타입 생성 및 빌드

--- a/src/executor.rs
+++ b/src/executor.rs
@@ -79,7 +79,7 @@ pub fn execute_workflow(workflow_path: &Path, runtime_js_path: &Path) -> Result<
 
 /// Remove import/export statements from JavaScript source.
 /// This is needed because we inline the runtime code.
-fn remove_imports(source: &str) -> String {
+pub fn remove_imports(source: &str) -> String {
     let mut result = Vec::new();
     for line in source.lines() {
         let trimmed = line.trim();

--- a/src/init/interactive.rs
+++ b/src/init/interactive.rs
@@ -204,10 +204,24 @@ pub async fn interactive_init(root: &Path) -> Result<()> {
         ..Default::default()
     };
 
-    // Save the custom config
-    let config_path = root.join(".gaji.toml");
-    config.save_to(&config_path)?;
-    println!("{} Created .gaji.toml with custom directories", "✓".green());
+    // Write the TS config file
+    let config_path = root.join(crate::config::TS_CONFIG_FILE);
+    let ts_content = format!(
+        r#"import {{ defineConfig }} from "./generated/index.js";
+
+export default defineConfig({{
+    workflows: "{}",
+    output: "{}",
+    generated: "{}",
+}});
+"#,
+        config.project.workflows_dir, config.project.output_dir, config.project.generated_dir,
+    );
+    std::fs::write(&config_path, ts_content)?;
+    println!(
+        "{} Created gaji.config.ts with custom directories",
+        "✓".green()
+    );
 
     // Create directories based on custom config
     tokio::fs::create_dir_all(root.join(&interactive_config.workflows_dir)).await?;


### PR DESCRIPTION
## Summary

Phase 3 of the gaji 1.0 plan: replace TOML configuration with TypeScript-based config loading, add integration tests for callback context, update init flow and documentation.

## Changes

- **3 new integration tests** (`tests/integration.rs`): `test_step_builder_callback_context`, `test_outputs_callback_context`, `test_job_builder_callback_context` — validate `_ctx` accumulation in `StepBuilder`/`JobBuilder`
- **TS config loading** (`src/config.rs`): add `Config::load_from_ts()` that strips types with oxc, executes in QuickJS via `__gha_set_config`; `Config::load()` tries `gaji.config.ts` first, falls back to `.gaji.toml`; remove `save()`/`save_to()`/`Serialize`
- **Make `remove_imports` public** (`src/executor.rs`): needed by config loader
- **Init flow** (`src/init/`): `gaji init` generates `gaji.config.ts` instead of `.gaji.toml`; add `GAJI_CONFIG_TEMPLATE`; update `.gitignore` for `gaji.config.local.ts`; update `print_next_steps()` with TS config example; update interactive init
- **Example template** (`src/init/templates.rs`): rewritten to use `steps()`/`jobs()` callback API
- **CLAUDE.md**: updated class hierarchy table, config file references, design patterns, common workflows
- **README.md**: all code examples and config section rewritten for callback API and TS config
- **Docs** (EN + KO): `configuration.md` rewritten for `gaji.config.ts`; `getting-started.md` examples updated to callback API
- **ROADMAP.md**: Phase 3 (3B–3F) marked complete

## Related Issues

Continues from Phase 1/2 (#62, #63). Phase 4 (API doc rewrites, TOML→TS migration command) tracked in ROADMAP.md.

## Checklist

- [x] `cargo test --all-features` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all --check` passes
- [x] Updated documentation if needed
- [x] Added tests for new functionality