### PR TITLE
refactor: Phase 4 — TOML migration, doc rewrites for callback builder API

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -739,64 +739,40 @@ Each file is independent:
 - ~~Updated `print_next_steps()` with TS config example~~
 - ~~Updated interactive init to write TS config directly~~
 
-### Phase 4 — Depends on Phase 3 (all parallel) ⬜ 미착수
+### ~~Phase 4 — Depends on Phase 3 (all parallel)~~ ✅
 
-#### 4A. `src/init/migration.rs` — TOML → TS config migration (moderate)
+#### ~~4A. `src/init/migration.rs` — TOML → TS config migration + migration codegen fix~~ ✅
 
-Depends on 3E.
+- ~~Detect existing `.gaji.toml` during init, generate `gaji.config.ts`~~
+- ~~Generate `gaji.config.local.ts` from `.gaji.local.toml` if present~~
+- ~~Prompt user before removing old TOML files~~
+- ~~Fix migration codegen: `.addStep()` → `.steps(s => s.add(...))`, `.addJob()` → `.jobs(j => j.add(...))`~~
 
-- Detect existing `.gaji.toml` during init
-- Generate equivalent `gaji.config.ts` from TOML values
-- Generate `gaji.config.local.ts` from `.gaji.local.toml` if present
-- Prompt user before removing old TOML files
+#### ~~4B. Config tests~~ ✅
 
-#### 4B. Config tests (moderate)
+- ~~`config.rs`: env var precedence test~~
+- ~~`integration.rs`: full pipeline test with `gaji.config.ts`~~
 
-Depends on 3E + 3F.
+#### ~~4C. `docs/reference/api.md` — API reference rewrite~~ ✅
 
-- Unit tests in `config.rs`: parse TS config, merge local, env var precedence
-- Integration test: full pipeline with `gaji.config.ts` instead of `.gaji.toml`
+- ~~`StepBuilder`, `JobBuilder` sections, constructor-only `JobConfig`, `defineConfig`/`GajiConfig`~~
+- ~~All examples updated to callback builder pattern~~
 
-#### 4C. `docs/reference/api.md` — API reference rewrite (moderate)
+#### ~~4D. `docs/guide/writing-workflows.md` — Guide rewrite~~ ✅
 
-Depends on Phase 2 (API shape).
+- ~~All examples updated to `.steps(s => s.add(...))`, `.jobs(j => j.add(...))`, constructor config~~
 
-- Add `StepBuilder` section with 4 `add` overloads
-- Update `Job` section: `Cx` generic, constructor-only `JobConfig`, `steps()` method, callback `outputs`
-- Add `JobBuilder` section with 4 `add` overloads
-- Update `Workflow` section: `Cx` generic, `jobs()` method
-- Remove `CompositeJob` section entirely
-- Rename `CompositeAction` → `Action` section with `steps()` method
-- Rename `JavaScriptAction` → `NodeAction` section
-- Rename `CallJob` → `WorkflowCall` section
-- Rename `CallAction` → `ActionRef` section, update `from()` signature
-- Update `jobOutputs()` section: note it's a compatibility helper, show `jobs()` callback as primary pattern
-- Add examples for each changed class showing callback/context usage
+#### ~~4E. Config documentation + all remaining doc updates~~ ✅
 
-#### 4D. `docs/guide/writing-workflows.md` — Guide rewrite (moderate)
+- ~~`docs/guide/migration.md`: Configuration migration section, all old API examples updated~~
+- ~~`docs/reference/actions.md`, `docs/guide/why.md`: old API examples updated~~
+- ~~`docs/examples/*.md`: all old API examples updated (simple-ci, matrix-build, composite-action, javascript-action)~~
+- ~~Korean mirrors: same changes applied to all `docs/ko/` files~~
 
-Depends on Phase 2 (API shape).
+#### ~~4F. Korean doc rewrites~~ ✅
 
-- Update "Steps" section: show `steps(s => s.add(...))` pattern with direct and callback forms
-- Replace `CompositeJob` section: show extending `Job` directly (CompositeJob removed)
-- Update `CallJob` → `WorkflowCall` in reusable workflow section
-- Rewrite "Outputs" section: show `outputs(output => ...)` and `jobs(j => j.add("id", output => ...))` as primary patterns, `jobOutputs()` as compatibility helper
-
-#### 4E. Config documentation (easy)
-
-Depends on 3E + 3F.
-
-- `docs/guide/writing-workflows.md`: Update configuration section with `gaji.config.ts` examples
-- `docs/reference/api.md`: Add `defineConfig` and `GajiConfig` to API reference
-- `docs/guide/migration.md`: Add `.gaji.toml` → `gaji.config.ts` migration instructions
-- `docs/ko/` mirrors: Apply same config documentation changes to Korean docs
-
-#### 4F. Korean doc rewrites (moderate)
-
-Depends on 4C + 4D.
-
-- `docs/ko/reference/api.md` — mirror 4C
-- `docs/ko/guide/writing-workflows.md` — mirror 4D
+- ~~`docs/ko/reference/api.md`, `docs/ko/guide/writing-workflows.md`, `docs/ko/guide/migration.md` — full rewrites~~
+- ~~`docs/ko/examples/*.md`, `docs/ko/reference/actions.md`, `docs/ko/guide/why.md` — old API examples updated~~
 
 ### Documentation Change Examples
 

--- a/docs/examples/javascript-action.md
+++ b/docs/examples/javascript-action.md
@@ -82,25 +82,29 @@ action.build("hello-world");
 
 // Use the action in a workflow
 const helloWorldJob = new Job("ubuntu-latest")
-  .addStep({
-    name: "Hello world action step",
-    id: "hello",
-    ...ActionRef.from(action).toJSON(),
-    with: {
-      "who-to-greet": "Mona the Octocat",
-    },
-  })
-  .addStep({
-    name: "Get the output time",
-    run: 'echo "The time was ${{ steps.hello.outputs.time }}"',
-  });
+  .steps(s => s
+    .add({
+      name: "Hello world action step",
+      id: "hello",
+      ...ActionRef.from(action).toJSON(),
+      with: {
+        "who-to-greet": "Mona the Octocat",
+      },
+    })
+    .add({
+      name: "Get the output time",
+      run: 'echo "The time was ${{ steps.hello.outputs.time }}"',
+    })
+  );
 
 const workflow = new Workflow({
   name: "Use JavaScript Action",
   on: {
     push: { branches: ["main"] },
   },
-}).addJob("hello_world_job", helloWorldJob);
+}).jobs(j => j
+    .add("hello_world_job", helloWorldJob)
+  );
 
 workflow.build("use-js-action");
 ```

--- a/docs/examples/simple-ci.md
+++ b/docs/examples/simple-ci.md
@@ -15,28 +15,30 @@ const setupNode = getAction("actions/setup-node@v4");
 
 // Define the test job
 const test = new Job("ubuntu-latest")
-  .addStep(checkout({
-    name: "Checkout code",
-  }))
-  .addStep(setupNode({
-    name: "Setup Node.js",
-    with: {
-      "node-version": "20",
-      cache: "npm",
-    },
-  }))
-  .addStep({
-    name: "Install dependencies",
-    run: "npm ci",
-  })
-  .addStep({
-    name: "Run linter",
-    run: "npm run lint",
-  })
-  .addStep({
-    name: "Run tests",
-    run: "npm test",
-  });
+  .steps(s => s
+    .add(checkout({
+      name: "Checkout code",
+    }))
+    .add(setupNode({
+      name: "Setup Node.js",
+      with: {
+        "node-version": "20",
+        cache: "npm",
+      },
+    }))
+    .add({
+      name: "Install dependencies",
+      run: "npm ci",
+    })
+    .add({
+      name: "Run linter",
+      run: "npm run lint",
+    })
+    .add({
+      name: "Run tests",
+      run: "npm test",
+    })
+  );
 
 // Create the workflow
 const workflow = new Workflow({
@@ -49,7 +51,9 @@ const workflow = new Workflow({
       branches: ["main"],
     },
   },
-}).addJob("test", test);
+}).jobs(j => j
+    .add("test", test)
+  );
 
 // Build to YAML
 workflow.build("ci");
@@ -127,11 +131,13 @@ setupNode({
 
 ```typescript
 const test = new Job("ubuntu-latest")
-  .addStep(checkout({}))
-  .addStep(setupNode({ with: { "node-version": "20" } }))
-  .addStep({ run: "npm ci" })
-  .addStep({ run: "npm test" })
-  .addStep({ run: "npm run build" });  // Add build
+  .steps(s => s
+    .add(checkout({}))
+    .add(setupNode({ with: { "node-version": "20" } }))
+    .add({ run: "npm ci" })
+    .add({ run: "npm test" })
+    .add({ run: "npm run build" })  // Add build
+  );
 ```
 
 ## Next Steps

--- a/docs/guide/why.md
+++ b/docs/guide/why.md
@@ -48,20 +48,24 @@ const checkout = getAction("actions/checkout@v5");
 const setupNode = getAction("actions/setup-node@v4");
 
 const build = new Job("ubuntu-latest")
-  .addStep(checkout({}))
-  .addStep(setupNode({
-    with: {
-      "node-version": "20",  // ✅ Correct key name, caught at compile time, full autocomplete and type checking
-      cache: "npm",
-    },
-  }))
-  .addStep({ run: "npm ci" })
-  .addStep({ run: "npm test" });
+  .steps(s => s
+    .add(checkout({}))
+    .add(setupNode({
+      with: {
+        "node-version": "20",  // ✅ Correct key name, caught at compile time, full autocomplete and type checking
+        cache: "npm",
+      },
+    }))
+    .add({ run: "npm ci" })
+    .add({ run: "npm test" })
+  );
 
 const workflow = new Workflow({
   name: "CI",
   on: { push: { branches: ["main"] } },
-}).addJob("build", build);
+}).jobs(j => j
+    .add("build", build)
+  );
 
 workflow.build("ci");
 ```

--- a/docs/ko/examples/composite-action.md
+++ b/docs/ko/examples/composite-action.md
@@ -19,17 +19,18 @@ class NodeTestJob extends Job {
   constructor(nodeVersion: string) {
     super("ubuntu-latest");
 
-    this
-      .addStep(checkout({ name: "Checkout code" }))
-      .addStep(setupNode({
+    this.steps(s => s
+      .add(checkout({ name: "Checkout code" }))
+      .add(setupNode({
         name: `Setup Node.js ${nodeVersion}`,
         with: {
           "node-version": nodeVersion,
           cache: "npm",
         },
       }))
-      .addStep({ name: "Install dependencies", run: "npm ci" })
-      .addStep({ name: "Run tests", run: "npm test" });
+      .add({ name: "Install dependencies", run: "npm ci" })
+      .add({ name: "Run tests", run: "npm test" })
+    );
   }
 }
 
@@ -37,10 +38,11 @@ class NodeTestJob extends Job {
 const workflow = new Workflow({
   name: "Test Matrix",
   on: { push: { branches: ["main"] } },
-})
-  .addJob("test-node-18", new NodeTestJob("18"))
-  .addJob("test-node-20", new NodeTestJob("20"))
-  .addJob("test-node-22", new NodeTestJob("22"));
+}).jobs(j => j
+  .add("test-node-18", new NodeTestJob("18"))
+  .add("test-node-20", new NodeTestJob("20"))
+  .add("test-node-22", new NodeTestJob("22"))
+);
 
 workflow.build("test-matrix");
 ```
@@ -51,39 +53,43 @@ workflow.build("test-matrix");
 class DeployJob extends Job {
   constructor(
     environment: "staging" | "production",
-    region: string = "us-east-1"
+    region: string = "us-east-1",
+    config: Record<string, unknown> = {}
   ) {
-    super("ubuntu-latest");
-
-    this
-      .env({
+    super("ubuntu-latest", {
+      env: {
         ENVIRONMENT: environment,
         REGION: region,
         API_URL: environment === "production"
           ? "https://api.example.com"
           : "https://staging.api.example.com",
-      })
-      .addStep(checkout({ name: "Checkout code" }))
-      .addStep(setupNode({
+      },
+      ...config,
+    });
+
+    this.steps(s => s
+      .add(checkout({ name: "Checkout code" }))
+      .add(setupNode({
         name: "Setup Node.js",
         with: {
           "node-version": "20",
           cache: "npm",
         },
       }))
-      .addStep({ name: "Install dependencies", run: "npm ci" })
-      .addStep({
+      .add({ name: "Install dependencies", run: "npm ci" })
+      .add({
         name: "Build",
         run: `npm run build:${environment}`,
       })
-      .addStep({
+      .add({
         name: `Deploy to ${environment}`,
         run: `npm run deploy`,
         env: {
           DEPLOY_TOKEN: "${{ secrets.DEPLOY_TOKEN }}",
           AWS_REGION: region,
         },
-      });
+      })
+    );
   }
 }
 
@@ -91,13 +97,15 @@ class DeployJob extends Job {
 const workflow = new Workflow({
   name: "Deploy",
   on: { push: { tags: ["v*"] } },
-})
-  .addJob("deploy-staging-us", new DeployJob("staging", "us-east-1"))
-  .addJob("deploy-staging-eu", new DeployJob("staging", "eu-west-1"))
-  .addJob("deploy-production",
-    new DeployJob("production", "us-east-1")
-      .needs(["deploy-staging-us", "deploy-staging-eu"])
-  );
+}).jobs(j => j
+  .add("deploy-staging-us", new DeployJob("staging", "us-east-1"))
+  .add("deploy-staging-eu", new DeployJob("staging", "eu-west-1"))
+  .add("deploy-production",
+    new DeployJob("production", "us-east-1", {
+      needs: ["deploy-staging-us", "deploy-staging-eu"],
+    })
+  )
+);
 
 workflow.build("deploy");
 ```

--- a/docs/ko/examples/javascript-action.md
+++ b/docs/ko/examples/javascript-action.md
@@ -78,25 +78,27 @@ action.build("hello-world");
 
 // 워크플로우에서 액션 사용
 const helloWorldJob = new Job("ubuntu-latest")
-  .addStep({
-    name: "Hello world action step",
-    id: "hello",
-    ...ActionRef.from(action).toJSON(),
-    with: {
-      "who-to-greet": "Mona the Octocat",
-    },
-  })
-  .addStep({
-    name: "Get the output time",
-    run: 'echo "The time was ${{ steps.hello.outputs.time }}"',
-  });
+  .steps(s => s
+    .add({
+      name: "Hello world action step",
+      id: "hello",
+      ...ActionRef.from(action).toJSON(),
+      with: {
+        "who-to-greet": "Mona the Octocat",
+      },
+    })
+    .add({
+      name: "Get the output time",
+      run: 'echo "The time was ${{ steps.hello.outputs.time }}"',
+    })
+  );
 
 const workflow = new Workflow({
   name: "Use JavaScript Action",
   on: {
     push: { branches: ["main"] },
   },
-}).addJob("hello_world_job", helloWorldJob);
+}).jobs(j => j.add("hello_world_job", helloWorldJob));
 
 workflow.build("use-js-action");
 ```

--- a/docs/ko/examples/matrix-build.md
+++ b/docs/ko/examples/matrix-build.md
@@ -11,31 +11,34 @@ const checkout = getAction("actions/checkout@v5");
 const setupNode = getAction("actions/setup-node@v4");
 
 // 매트릭스 테스트 작업 정의
-const test = new Job("${{ matrix.os }}")
-  .strategy({
-    matrix: {
-      os: ["ubuntu-latest", "macos-latest", "windows-latest"],
-      node: ["18", "20", "22"],
+const test = new Job("${{ matrix.os }}", {
+    strategy: {
+      matrix: {
+        os: ["ubuntu-latest", "macos-latest", "windows-latest"],
+        node: ["18", "20", "22"],
+      },
     },
   })
-  .addStep(checkout({
-    name: "Checkout code",
-  }))
-  .addStep(setupNode({
-    name: "Setup Node.js ${{ matrix.node }}",
-    with: {
-      "node-version": "${{ matrix.node }}",
-      cache: "npm",
-    },
-  }))
-  .addStep({
-    name: "Install dependencies",
-    run: "npm ci",
-  })
-  .addStep({
-    name: "Run tests",
-    run: "npm test",
-  });
+  .steps(s => s
+    .add(checkout({
+      name: "Checkout code",
+    }))
+    .add(setupNode({
+      name: "Setup Node.js ${{ matrix.node }}",
+      with: {
+        "node-version": "${{ matrix.node }}",
+        cache: "npm",
+      },
+    }))
+    .add({
+      name: "Install dependencies",
+      run: "npm ci",
+    })
+    .add({
+      name: "Run tests",
+      run: "npm test",
+    })
+  );
 
 // 워크플로우 생성
 const workflow = new Workflow({
@@ -48,7 +51,7 @@ const workflow = new Workflow({
       branches: ["main"],
     },
   },
-}).addJob("test", test);
+}).jobs(j => j.add("test", test));
 
 workflow.build("matrix-test");
 ```

--- a/docs/ko/examples/simple-ci.md
+++ b/docs/ko/examples/simple-ci.md
@@ -12,28 +12,30 @@ const setupNode = getAction("actions/setup-node@v4");
 
 // 테스트 작업 정의
 const test = new Job("ubuntu-latest")
-  .addStep(checkout({
-    name: "Checkout code",
-  }))
-  .addStep(setupNode({
-    name: "Setup Node.js",
-    with: {
-      "node-version": "20",
-      cache: "npm",
-    },
-  }))
-  .addStep({
-    name: "Install dependencies",
-    run: "npm ci",
-  })
-  .addStep({
-    name: "Run linter",
-    run: "npm run lint",
-  })
-  .addStep({
-    name: "Run tests",
-    run: "npm test",
-  });
+  .steps(s => s
+    .add(checkout({
+      name: "Checkout code",
+    }))
+    .add(setupNode({
+      name: "Setup Node.js",
+      with: {
+        "node-version": "20",
+        cache: "npm",
+      },
+    }))
+    .add({
+      name: "Install dependencies",
+      run: "npm ci",
+    })
+    .add({
+      name: "Run linter",
+      run: "npm run lint",
+    })
+    .add({
+      name: "Run tests",
+      run: "npm test",
+    })
+  );
 
 // 워크플로우 생성
 const workflow = new Workflow({
@@ -46,7 +48,7 @@ const workflow = new Workflow({
       branches: ["main"],
     },
   },
-}).addJob("test", test);
+}).jobs(j => j.add("test", test));
 
 // YAML로 빌드
 workflow.build("ci");

--- a/docs/ko/guide/migration.md
+++ b/docs/ko/guide/migration.md
@@ -85,22 +85,23 @@ const action = new Action({
 });
 
 action
-    .addStep(checkout({}))
-    .addStep({
-        name: "Install dependencies",
-        run: "npm ci",
-        shell: "bash",
-    })
-    .addStep(cache({
-        id: "cache",
-        name: "Cache node_modules",
-        with: {
-            path: "node_modules",
-            key: "${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}",
-        },
-    }));
-
-action.build("setup-env");
+    .steps(s => s
+        .add(checkout({}))
+        .add({
+            name: "Install dependencies",
+            run: "npm ci",
+            shell: "bash",
+        })
+        .add(cache({
+            id: "cache",
+            name: "Cache node_modules",
+            with: {
+                path: "node_modules",
+                key: "${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}",
+            },
+        }))
+    )
+    .build("setup-env");
 ```
 
 ### JavaScript 액션
@@ -251,29 +252,33 @@ gaji add actions/setup-node@v4
 // ---cut---
 import { getAction, Job, Workflow } from "../generated/index.js";
 
+// 액션 가져오기
 const checkout = getAction("actions/checkout@v5");
 const setupNode = getAction("actions/setup-node@v4");
 
-const build = new Job("ubuntu-latest")
-  .addStep(checkout({}))
-  .addStep(setupNode({
-    with: {
-      "node-version": "20",
-    },
-  }))
-  .addStep({ run: "npm ci" })
-  .addStep({ run: "npm test" });
-
-const workflow = new Workflow({
+// 워크플로우와 job, 스텝 생성
+new Workflow({
   name: "CI",
   on: {
     push: {
       branches: ["main"],
     },
   },
-}).addJob("build", build);
-
-workflow.build("ci");
+})
+  .jobs(j => j
+    .add("build",
+      new Job("ubuntu-latest")
+        .steps(s => s
+          .add(checkout({}))
+          .add(setupNode({
+            with: { "node-version": "20" },
+          }))
+          .add({ run: "npm ci" })
+          .add({ run: "npm test" })
+        )
+    )
+  )
+  .build("ci");
 ```
 
 ### 4단계: 빌드 및 검증
@@ -282,6 +287,290 @@ workflow.build("ci");
 # TypeScript를 YAML로 빌드
 gaji build
 ```
+
+### 5단계: 정리
+
+검증이 끝나면 백업 파일을 삭제합니다:
+
+```bash
+rm .github/workflows/ci.yml.backup
+```
+
+## 자주 사용되는 마이그레이션 패턴
+
+### 복수 Job
+
+**YAML:**
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm test
+
+  build:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - run: npm run build
+```
+
+**TypeScript:**
+```typescript
+const test = new Job("ubuntu-latest")
+  .steps(s => s
+    .add({ run: "npm test" })
+  );
+
+const build = new Job("ubuntu-latest", {
+  needs: ["test"],
+})
+  .steps(s => s
+    .add({ run: "npm run build" })
+  );
+
+new Workflow({
+  name: "CI",
+  on: { push: { branches: ["main"] } },
+})
+  .jobs(j => j
+    .add("test", test)
+    .add("build", build)
+  )
+  .build("ci");
+```
+
+### 매트릭스 전략
+
+**YAML:**
+```yaml
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+        node: [18, 20, 22]
+```
+
+**TypeScript:**
+```typescript
+const test = new Job("${{ matrix.os }}", {
+  strategy: {
+    matrix: {
+      os: ["ubuntu-latest", "macos-latest"],
+      node: ["18", "20", "22"],
+    },
+  },
+})
+  .steps(s => s
+    .add(checkout({}))
+  );
+```
+
+### 환경 변수
+
+**YAML:**
+```yaml
+env:
+  NODE_ENV: production
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      API_KEY: ${{ secrets.API_KEY }}
+```
+
+**TypeScript:**
+```typescript
+new Workflow({
+  name: "Deploy",
+  on: { push: { branches: ["main"] } },
+  env: {
+    NODE_ENV: "production",
+  },
+})
+  .jobs(j => j
+    .add("deploy",
+      new Job("ubuntu-latest", {
+        env: {
+          API_KEY: "${{ secrets.API_KEY }}",
+        },
+      })
+    )
+  )
+  .build("deploy");
+```
+
+### 조건부 스텝
+
+**YAML:**
+```yaml
+steps:
+  - name: Deploy
+    if: github.ref == 'refs/heads/main'
+    run: npm run deploy
+```
+
+**TypeScript:**
+```typescript
+.add({
+  name: "Deploy",
+  if: "github.ref == 'refs/heads/main'",
+  run: "npm run deploy",
+})
+```
+
+### Job 출력
+
+**YAML:**
+```yaml
+jobs:
+  build:
+    outputs:
+      version: ${{ steps.version.outputs.value }}
+    steps:
+      - id: version
+        run: echo "value=1.0.0" >> $GITHUB_OUTPUT
+```
+
+**TypeScript:**
+```typescript
+const build = new Job("ubuntu-latest")
+  .steps(s => s
+    .add({
+      id: "version",
+      run: 'echo "value=1.0.0" >> $GITHUB_OUTPUT',
+    })
+  )
+  .outputs({
+    version: "${{ steps.version.outputs.value }}",
+  });
+```
+
+## 설정 마이그레이션
+
+이전 `.gaji.toml` 설정 파일을 사용하는 프로젝트는 `gaji.config.ts`로 마이그레이션할 수 있습니다.
+
+### 자동 마이그레이션
+
+`.gaji.toml`이 있는 프로젝트에서 `gaji init`을 실행하면 gaji가 파일을 감지하고 마이그레이션을 제안합니다:
+
+```bash
+gaji init
+# Detected .gaji.toml configuration file.
+# Migrate to gaji.config.ts? [y/N]
+```
+
+확인하면 다음 작업이 수행됩니다:
+
+1. `.gaji.toml`을 읽고 `defineConfig()`을 사용하는 `gaji.config.ts` 파일 생성
+2. `.gaji.local.toml`이 있으면 `gaji.config.local.ts`도 생성
+3. 마이그레이션 성공 후 기존 TOML 파일 삭제
+
+### 수동 마이그레이션
+
+수동으로 마이그레이션하려면 프로젝트 루트에 `gaji.config.ts`를 생성합니다:
+
+**변환 전** (`.gaji.toml`):
+
+```toml
+workflows = "src/workflows"
+output = ".github"
+
+[build]
+cache_ttl_days = 14
+
+[github]
+token = "ghp_xxx"
+```
+
+**변환 후** (`gaji.config.ts`):
+
+```typescript
+import { defineConfig } from "./generated/index.js";
+
+export default defineConfig({
+  workflows: "src/workflows",
+  build: {
+    cacheTtlDays: 14,
+  },
+});
+```
+
+TOML 키는 `snake_case`이고 TypeScript 설정은 `camelCase`를 사용합니다. `github.token` 같은 비밀 값은 `gaji.config.local.ts`에 넣어야 합니다 (`.gitignore`에 추가):
+
+```typescript
+// gaji.config.local.ts
+import { defineConfig } from "./generated/index.js";
+
+export default defineConfig({
+  github: {
+    token: "ghp_xxx",
+  },
+});
+```
+
+## 마이그레이션 체크리스트
+
+1. gaji 설치
+2. 프로젝트 초기화
+3. 워크플로우에 사용된 모든 액션 추가
+4. YAML을 TypeScript로 변환
+5. 생성된 YAML 빌드 및 검증
+6. 브랜치에서 워크플로우 테스트
+7. 백업 파일 삭제
+8. 문서 업데이트
+
+## 팁
+
+### 1. 작은 것부터 시작
+
+가장 간단한 워크플로우부터 하나씩 마이그레이션하세요.
+
+### 2. 자동 마이그레이션 활용
+
+복잡한 워크플로우는 gaji의 자동 변환을 먼저 사용하세요:
+
+```bash
+gaji init --migrate
+```
+
+그런 다음 생성된 TypeScript를 다듬으세요.
+
+### 3. 브랜치에서 테스트
+
+마이그레이션한 워크플로우는 병합 전에 항상 기능 브랜치에서 테스트하세요.
+
+### 4. 전환 기간에 양쪽 유지
+
+마이그레이션 중에는 YAML과 TypeScript 버전을 함께 유지할 수 있습니다:
+- 기존 워크플로우는 `.backup` 확장자로 백업 (예: `ci.yml.backup`)
+- 새 워크플로우: `workflows/*.ts`에서 `.github/workflows/*.yml`로 생성
+
+## 문제 해결
+
+### 타입이 생성되지 않음
+
+모든 액션이 추가되었는지 확인하세요:
+
+```bash
+gaji add actions/checkout@v5
+gaji dev
+```
+
+### 빌드 실패
+
+TypeScript 오류를 확인하세요:
+
+```bash
+npx tsc --noEmit
+```
+
+### 생성된 YAML이 원본과 다름
+
+사소한 포맷 차이는 정상입니다. 포맷이 아닌 기능을 검증하세요.
 
 ## 다음 단계
 

--- a/docs/ko/guide/why.md
+++ b/docs/ko/guide/why.md
@@ -48,20 +48,22 @@ const checkout = getAction("actions/checkout@v5");
 const setupNode = getAction("actions/setup-node@v4");
 
 const build = new Job("ubuntu-latest")
-  .addStep(checkout({}))
-  .addStep(setupNode({
-    with: {
-      "node-version": "20",  // ✅ 올바른 키 이름, 컴파일 시점에 오류 포착,완전한 자동완성 및 타입 체크
-      cache: "npm",  
-    },
-  }))
-  .addStep({ run: "npm ci" })
-  .addStep({ run: "npm test" });
+  .steps(s => s
+    .add(checkout({}))
+    .add(setupNode({
+      with: {
+        "node-version": "20",  // ✅ 올바른 키 이름, 컴파일 시점에 오류 포착,완전한 자동완성 및 타입 체크
+        cache: "npm",
+      },
+    }))
+    .add({ run: "npm ci" })
+    .add({ run: "npm test" })
+  );
 
 const workflow = new Workflow({
   name: "CI",
   on: { push: { branches: ["main"] } },
-}).addJob("build", build);
+}).jobs(j => j.add("build", build));
 
 workflow.build("ci");
 ```

--- a/docs/ko/guide/writing-workflows.md
+++ b/docs/ko/guide/writing-workflows.md
@@ -22,18 +22,20 @@ import { getAction, Job, Workflow } from "../generated/index.js";
 // 1. 액션 가져오기
 const checkout = getAction("actions/checkout@v5");
 
-// 2. 작업 생성
-const build = new Job("ubuntu-latest")
-  .addStep(checkout({}));
-
-// 3. 워크플로우 생성
-const workflow = new Workflow({
+// 2. 워크플로우와 job, 스텝 생성
+new Workflow({
   name: "CI",
   on: { push: { branches: ["main"] } },
-}).addJob("build", build);
-
-// 4. YAML로 빌드
-workflow.build("ci");
+})
+  .jobs(j => j
+    .add("build",
+      new Job("ubuntu-latest")
+        .steps(s => s
+          .add(checkout({}))
+        )
+    )
+  )
+  .build("ci");
 ```
 
 ## 액션 사용하기
@@ -77,15 +79,233 @@ const step = checkout({
 - ✅ action.yml의 문서
 - ✅ 기본값 표시
 
+## Job 생성
+
+Job은 `Job` 클래스로 생성합니다:
+
+```typescript
+const job = new Job("ubuntu-latest");
+```
+
+### 지원되는 러너
+
+```typescript
+// Ubuntu
+new Job("ubuntu-latest")
+new Job("ubuntu-22.04")
+new Job("ubuntu-20.04")
+
+// macOS
+new Job("macos-latest")
+new Job("macos-13")
+new Job("macos-12")
+
+// Windows
+new Job("windows-latest")
+new Job("windows-2022")
+new Job("windows-2019")
+
+// Self-hosted
+new Job("self-hosted")
+new Job(["self-hosted", "linux", "x64"])
+```
+
+### 스텝 추가
+
+`.steps()` 콜백과 `.add()`로 스텝을 추가합니다:
+
+```typescript
+const job = new Job("ubuntu-latest")
+  .steps(s => s
+    // 액션 스텝
+    .add(checkout({
+      name: "Checkout",
+    }))
+
+    // run 명령
+    .add({
+      name: "Build",
+      run: "npm run build",
+    })
+
+    // 여러 줄 명령
+    .add({
+      name: "Install dependencies",
+      run: `
+        npm ci
+        npm run build
+        npm test
+      `.trim(),
+    })
+
+    // 환경 변수 포함
+    .add({
+      name: "Deploy",
+      run: "npm run deploy",
+      env: {
+        NODE_ENV: "production",
+        API_KEY: "${{ secrets.API_KEY }}",
+      },
+    })
+
+    // 조건부 스텝
+    .add({
+      name: "Upload artifacts",
+      if: "success()",
+      run: "npm run upload",
+    })
+  );
+```
+
+## 워크플로우 생성
+
+### 기본 워크플로우
+
+```typescript
+new Workflow({
+  name: "CI",
+  on: {
+    push: {
+      branches: ["main"],
+    },
+  },
+})
+  .jobs(j => j
+    .add("build", buildJob)
+  )
+  .build("ci");
+```
+
+### 트리거 이벤트
+
+#### Push
+
+```typescript
+on: {
+  push: {
+    branches: ["main", "develop"],
+    tags: ["v*"],
+    paths: ["src/**", "tests/**"],
+  },
+}
+```
+
+#### Pull Request
+
+```typescript
+on: {
+  pull_request: {
+    branches: ["main"],
+    types: ["opened", "synchronize", "reopened"],
+  },
+}
+```
+
+#### Schedule (Cron)
+
+```typescript
+on: {
+  schedule: [
+    { cron: "0 0 * * *" },  // 매일 자정
+  ],
+}
+```
+
+#### 복수 트리거
+
+```typescript
+on: {
+  push: { branches: ["main"] },
+  pull_request: { branches: ["main"] },
+  workflow_dispatch: {},  // 수동 트리거
+}
+```
+
+### 복수 Job
+
+```typescript
+const test = new Job("ubuntu-latest")
+  .steps(s => s
+    .add(checkout({}))
+    .add({ run: "npm test" })
+  );
+
+const build = new Job("ubuntu-latest")
+  .steps(s => s
+    .add(checkout({}))
+    .add({ run: "npm run build" })
+  );
+
+new Workflow({
+  name: "CI",
+  on: { push: { branches: ["main"] } },
+})
+  .jobs(j => j
+    .add("test", test)
+    .add("build", build)
+  )
+  .build("ci");
+```
+
+### Job 의존성
+
+`JobConfig` 생성자 파라미터에서 `needs`를 사용합니다:
+
+```typescript
+const test = new Job("ubuntu-latest")
+  .steps(s => s
+    .add({ run: "npm test" })
+  );
+
+const deploy = new Job("ubuntu-latest", {
+  needs: ["test"],  // test job 완료 대기
+})
+  .steps(s => s
+    .add({ run: "npm run deploy" })
+  );
+
+new Workflow({
+  name: "Deploy",
+  on: { push: { branches: ["main"] } },
+})
+  .jobs(j => j
+    .add("test", test)
+    .add("deploy", deploy)
+  )
+  .build("deploy");
+```
+
+## 매트릭스 빌드
+
+`JobConfig` 생성자에서 `strategy`를 사용합니다:
+
+```typescript
+const test = new Job("${{ matrix.os }}", {
+  strategy: {
+    matrix: {
+      os: ["ubuntu-latest", "macos-latest", "windows-latest"],
+      node: ["18", "20", "22"],
+    },
+  },
+})
+```
+
+생성된 YAML이 포함된 전체 매트릭스 빌드 예제는 [매트릭스 빌드 예제](/ko/examples/matrix-build)를 참조하세요.
+
+## 컴포지트 액션
+
+`Action`을 사용하여 재사용 가능한 [컴포지트 액션](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action)을 만듭니다. 입력을 정의하고, `.steps()`로 스텝을 추가한 뒤, `.build()`로 리포지토리에 `action.yml`을 생성합니다.
+
+전체 예제는 [컴포지트 액션 예제](/ko/examples/composite-action)를 참조하세요. 전체 API는 [Action](/ko/reference/api#action)을 참조하세요.
+
 ## Job 상속
 
 `Job`을 상속하여 재사용 가능한 파라미터화된 Job 템플릿을 만들 수 있습니다:
 
 ```ts twoslash
-// @noErrors
 // @filename: workflows/example.ts
 // ---cut---
-import { Job, getAction } from "../generated/index.js";
+import { Job, getAction, Workflow } from "../generated/index.js";
 
 const checkout = getAction("actions/checkout@v5");
 const setupNode = getAction("actions/setup-node@v4");
@@ -93,11 +313,12 @@ const setupNode = getAction("actions/setup-node@v4");
 class NodeTestJob extends Job {
   constructor(nodeVersion: string) {
     super("ubuntu-latest");
-    this
-      .addStep(checkout({}))
-      .addStep(setupNode({ with: { "node-version": nodeVersion } }))
-      .addStep({ run: "npm ci" })
-      .addStep({ run: "npm test" });
+    this.steps(s => s
+      .add(checkout({}))
+      .add(setupNode({ with: { "node-version": nodeVersion } }))
+      .add({ run: "npm ci" })
+      .add({ run: "npm test" })
+    );
   }
 }
 ```
@@ -119,23 +340,7 @@ import { getAction, Job, Workflow } from "../generated/index.js";
 const checkout = getAction("actions/checkout@v5");
 const setupNode = getAction("actions/setup-node@v4");
 
-const publish = new Job("ubuntu-latest")
-  .addStep(checkout({ name: "Checkout" }))
-  .addStep(setupNode({
-    name: "Setup Node.js",
-    with: { "node-version": "20", cache: "npm" },
-  }))
-  .addStep({ name: "Install dependencies", run: "npm ci" })
-  .addStep({ name: "Build", run: "npm run build" })
-  .addStep({
-    name: "Publish",
-    run: "npm run publish:${{ inputs.environment }}",
-    env: {
-      DEPLOY_TOKEN: "${{ secrets.DEPLOY_TOKEN }}",
-    },
-  });
-
-const workflow = new Workflow({
+new Workflow({
   name: "Publish",
   on: {
     workflow_call: {
@@ -152,9 +357,29 @@ const workflow = new Workflow({
       },
     },
   },
-}).addJob("publish", publish);
-
-workflow.build("publish");
+})
+  .jobs(j => j
+    .add("publish",
+      new Job("ubuntu-latest")
+        .steps(s => s
+          .add(checkout({ name: "Checkout" }))
+          .add(setupNode({
+            name: "Setup Node.js",
+            with: { "node-version": "20", cache: "npm" },
+          }))
+          .add({ name: "Install dependencies", run: "npm ci" })
+          .add({ name: "Build", run: "npm run build" })
+          .add({
+            name: "Publish",
+            run: "npm run publish:${{ inputs.environment }}",
+            env: {
+              DEPLOY_TOKEN: "${{ secrets.DEPLOY_TOKEN }}",
+            },
+          })
+        )
+    )
+  )
+  .build("publish");
 ```
 
 다음으로, `WorkflowCall`을 사용하여 이 워크플로우를 환경별로 호출합니다. `needs`로 alpha → staging → live 순서를 지정합니다:
@@ -165,29 +390,33 @@ workflow.build("publish");
 // ---cut---
 import { WorkflowCall, Workflow } from "../generated/index.js";
 
-const alpha = new WorkflowCall("./.github/workflows/publish.yml")
-  .with({ environment: "alpha" })
-  .secrets("inherit");
+const alpha = new WorkflowCall("./.github/workflows/publish.yml", {
+  with: { environment: "alpha" },
+  secrets: "inherit",
+});
 
-const staging = new WorkflowCall("./.github/workflows/publish.yml")
-  .with({ environment: "staging" })
-  .secrets("inherit")
-  .needs(["publish-alpha"]);
+const staging = new WorkflowCall("./.github/workflows/publish.yml", {
+  with: { environment: "staging" },
+  secrets: "inherit",
+  needs: ["publish-alpha"],
+});
 
-const live = new WorkflowCall("./.github/workflows/publish.yml")
-  .with({ environment: "live" })
-  .secrets("inherit")
-  .needs(["publish-staging"]);
+const live = new WorkflowCall("./.github/workflows/publish.yml", {
+  with: { environment: "live" },
+  secrets: "inherit",
+  needs: ["publish-staging"],
+});
 
-const workflow = new Workflow({
+new Workflow({
   name: "Release",
   on: { push: { tags: ["v*"] } },
 })
-  .addJob("publish-alpha", alpha)
-  .addJob("publish-staging", staging)
-  .addJob("publish-live", live);
-
-workflow.build("release");
+  .jobs(j => j
+    .add("publish-alpha", alpha)
+    .add("publish-staging", staging)
+    .add("publish-live", live)
+  )
+  .build("release");
 ```
 
 이 구조의 장점은 배포 로직이 `publish.yml` 한 곳에만 존재한다는 점입니다. 배포 스텝을 수정해야 할 때 `publish.ts`만 고치면 세 환경 모두에 반영됩니다.
@@ -197,6 +426,41 @@ workflow.build("release");
 `DockerAction`으로 [Docker 컨테이너 액션](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-docker-container-action)을 정의합니다. `Dockerfile` 또는 `docker://` 접두사를 붙인 Docker Hub 이미지를 지정할 수 있습니다.
 
 전체 API와 예제는 [DockerAction API](/ko/reference/api#dockeraction)를 참조하세요.
+
+## 환경 변수
+
+### 워크플로우 수준
+
+```typescript
+new Workflow({
+  name: "CI",
+  on: { push: { branches: ["main"] } },
+  env: {
+    NODE_ENV: "production",
+  },
+});
+```
+
+### Job 수준
+
+```typescript
+new Job("ubuntu-latest", {
+  env: {
+    DATABASE_URL: "${{ secrets.DATABASE_URL }}",
+  },
+});
+```
+
+### 스텝 수준
+
+```typescript
+.add({
+  run: "npm run deploy",
+  env: {
+    API_KEY: "${{ secrets.API_KEY }}",
+  },
+})
+```
 
 ## 출력
 
@@ -211,59 +475,69 @@ const checkout = getAction("actions/checkout@v5");
 const step = checkout({ id: "my-checkout" });
 step.outputs.ref     // "${{ steps.my-checkout.outputs.ref }}"
 step.outputs.commit  // "${{ steps.my-checkout.outputs.commit }}"
-
-const job = new Job("ubuntu-latest")
-  .addStep(step)
-  .addStep({ run: `echo ${step.outputs.ref}` });
 ```
 
 ### Job 간 출력 전달
 
-`jobOutputs()`를 사용하여 다운스트림 job을 위한 타입이 지정된 참조를 생성합니다. Job의 `.outputs()` 키를 읽어 <code v-pre>${{ needs.&lt;jobId&gt;.outputs.&lt;key&gt; }}</code> 표현식을 생성합니다:
+기본 패턴은 `.jobs()` 콜백을 사용하는 것으로, job 출력 컨텍스트가 자동으로 전달됩니다:
 
 ```typescript
 const checkout = getAction("actions/checkout@v5");
-const step = checkout({ id: "my-checkout" });
 
-// 타입이 지정된 출력으로 job 정의
+new Workflow({ name: "CI", on: { push: {} } })
+  .jobs(j => j
+    .add("build",
+      new Job("ubuntu-latest")
+        .steps(s => s
+          .add(checkout({ id: "co" }))
+        )
+        .outputs(output => ({ ref: output.co.ref }))
+    )
+    .add("deploy", output =>
+      new Job("ubuntu-latest", { needs: ["build"] })
+        .steps(s => s
+          .add({ run: "echo " + output.build.ref })
+        )
+    )
+  )
+  .build("ci");
+```
+
+`deploy` 콜백의 `output` 파라미터는 `build` job이 선언한 출력에 대한 타입이 지정된 접근을 제공하며, <code v-pre>${{ needs.build.outputs.ref }}</code> 표현식을 생성합니다.
+
+Job을 별도의 변수로 정의할 때는 `jobOutputs()`를 호환성 헬퍼로 사용할 수 있습니다:
+
+```typescript
 const build = new Job("ubuntu-latest")
-  .addStep(step)
-  .outputs({ ref: step.outputs.ref, sha: step.outputs.commit });
+  .steps(s => s.add(checkout({ id: "co" })))
+  .outputs(output => ({ ref: output.co.ref }));
 
-// 다운스트림 job을 위한 타입이 지정된 참조 생성
 const buildOutputs = jobOutputs("build", build);
 // buildOutputs.ref → "${{ needs.build.outputs.ref }}"
-// buildOutputs.sha → "${{ needs.build.outputs.sha }}"
-
-const deploy = new Job("ubuntu-latest")
-  .needs("build")
-  .addStep({ run: `deploy --ref ${buildOutputs.ref}` });
-
-const workflow = new Workflow({
-  name: "CI",
-  on: { push: { branches: ["main"] } },
-})
-  .addJob("build", build)
-  .addJob("deploy", deploy);
 ```
 
 수동으로 정의된 출력(`$GITHUB_OUTPUT`에 쓰는 `run` 스텝 등)도 사용할 수 있습니다:
 
 ```typescript
-const setup = new Job("ubuntu-latest")
-  .addStep({
-    id: "version",
-    run: 'echo "value=1.0.0" >> $GITHUB_OUTPUT',
-  })
-  .outputs({
-    version: "${{ steps.version.outputs.value }}",
-  });
-
-const setupOutputs = jobOutputs("setup", setup);
-
-const deploy = new Job("ubuntu-latest")
-  .needs("setup")
-  .addStep({ run: `deploy --version ${setupOutputs.version}` });
+new Workflow({ name: "CI", on: { push: { tags: ["v*"] } } })
+  .jobs(j => j
+    .add("setup",
+      new Job("ubuntu-latest")
+        .steps(s => s
+          .add({ id: "version", run: 'echo "value=1.0.0" >> $GITHUB_OUTPUT' })
+        )
+        .outputs({
+          version: "${{ steps.version.outputs.value }}",
+        })
+    )
+    .add("deploy", output =>
+      new Job("ubuntu-latest", { needs: ["setup"] })
+        .steps(s => s
+          .add({ run: "deploy --version " + output.setup.version })
+        )
+    )
+  )
+  .build("ci");
 ```
 
 ## 팁
@@ -309,20 +583,20 @@ gaji는 JavaScript 문자열을 YAML로 변환하므로, JavaScript에서 이미
 
 ```typescript
 // TypeScript에서 \n은 줄바꿈 문자
-.addStep({ run: "echo \"hello\nworld\"" })
+.add({ run: "echo \"hello\nworld\"" })
 ```
 
 JS 문자열에는 실제 줄바꿈이 포함되어 있어 YAML에서 올바르게 처리됩니다. 하지만 YAML 출력에 리터럴 `\n` 문자를 그대로 유지하려면 이중 이스케이프가 필요합니다:
 
 ```typescript
 // YAML에서 리터럴 \n을 유지하려면 이중 이스케이프
-.addStep({ run: "echo hello\\nworld" })
+.add({ run: "echo hello\\nworld" })
 ```
 
 **팁**: 여러 줄 명령어에는 이스케이프 시퀀스 대신 템플릿 리터럴을 사용하세요:
 
 ```typescript
-.addStep({
+.add({
   run: `
     echo hello
     echo world

--- a/docs/ko/reference/actions.md
+++ b/docs/ko/reference/actions.md
@@ -24,12 +24,14 @@ const setupNode = getAction("actions/setup-node@v4");
 
 // 워크플로우에서 사용
 const job = new Job("ubuntu-latest")
-  .addStep(checkout({}))
-  .addStep(setupNode({
-    with: {
-      "node-version": "20",  // ✅ 타입 안전!
-    },
-  }));
+  .steps(s => s
+    .add(checkout({}))
+    .add(setupNode({
+      with: {
+        "node-version": "20",  // ✅ 타입 안전!
+      },
+    }))
+  );
 ```
 
 ## 액션 참조 형식
@@ -118,10 +120,10 @@ gaji add actions/checkout@v5
 const checkout = getAction("actions/checkout@v5");
 
 // 기본 사용
-.addStep(checkout({}))
+.add(checkout({}))
 
 // 옵션과 함께
-.addStep(checkout({
+.add(checkout({
   with: {
     repository: "owner/repo",
     ref: "main",
@@ -142,7 +144,7 @@ gaji add actions/setup-node@v4
 ```typescript
 const setupNode = getAction("actions/setup-node@v4");
 
-.addStep(setupNode({
+.add(setupNode({
   with: {
     "node-version": "20",
     cache: "npm",
@@ -161,7 +163,7 @@ gaji add actions/cache@v4
 ```typescript
 const cache = getAction("actions/cache@v4");
 
-.addStep(cache({
+.add(cache({
   with: {
     path: "node_modules",
     key: "${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}",
@@ -181,7 +183,7 @@ gaji add actions/upload-artifact@v4
 ```typescript
 const uploadArtifact = getAction("actions/upload-artifact@v4");
 
-.addStep(uploadArtifact({
+.add(uploadArtifact({
   with: {
     name: "build-output",
     path: "dist/",
@@ -200,7 +202,7 @@ gaji add actions/download-artifact@v4
 ```typescript
 const downloadArtifact = getAction("actions/download-artifact@v4");
 
-.addStep(downloadArtifact({
+.add(downloadArtifact({
   with: {
     name: "build-output",
     path: "dist/",
@@ -231,15 +233,17 @@ const setupBuildx = getAction("docker/setup-buildx-action@v3");
 const buildPush = getAction("docker/build-push-action@v5");
 
 const job = new Job("ubuntu-latest")
-  .addStep(checkout({}))
-  .addStep(setupBuildx({}))
-  .addStep(buildPush({
-    with: {
-      context: ".",
-      push: true,
-      tags: "user/app:latest",
-    },
-  }));
+  .steps(s => s
+    .add(checkout({}))
+    .add(setupBuildx({}))
+    .add(buildPush({
+      with: {
+        context: ".",
+        push: true,
+        tags: "user/app:latest",
+      },
+    }))
+  );
 ```
 
 ## 로컬 액션
@@ -249,7 +253,7 @@ const job = new Job("ubuntu-latest")
 ```typescript
 const myAction = getAction("./my-action");
 
-.addStep(myAction({
+.add(myAction({
   with: {
     input: "value",
   },

--- a/docs/ko/reference/api.md
+++ b/docs/ko/reference/api.md
@@ -9,9 +9,9 @@ gaji의 TypeScript API에 대한 레퍼런스입니다.
 GitHub Actions 워크플로우를 표현합니다.
 
 ```typescript
-class Workflow {
+class Workflow<Cx = {}> {
   constructor(config: WorkflowConfig)
-  addJob(id: string, job: Job<any> | WorkflowCall): this
+  jobs<NewCx>(callback: (j: JobBuilder<{}>) => JobBuilder<NewCx>): Workflow<NewCx>
   static fromObject(def: WorkflowDefinition, id?: string): Workflow
   build(filename?: string): void
   toJSON(): WorkflowDefinition
@@ -20,7 +20,7 @@ class Workflow {
 
 | 메서드 | 설명 |
 |--------|------|
-| `addJob(id, job)` | 워크플로우에 job을 추가합니다. `Job`, `WorkflowCall`을 받습니다. |
+| `jobs(callback)` | `JobBuilder` 콜백을 통해 워크플로우 job을 정의합니다. 콜백은 빈 `JobBuilder`를 받아 `.add()`로 job을 추가한 뒤 반환합니다. |
 | `fromObject(def, id?)` | `WorkflowDefinition` 객체로부터 Workflow를 생성합니다. 기존 YAML 형태의 정의를 래핑할 때 유용합니다. |
 | `build(filename?)` | 워크플로우를 YAML로 컴파일합니다. |
 | `toJSON()` | `WorkflowDefinition` 객체로 직렬화합니다. |
@@ -29,11 +29,12 @@ class Workflow {
 
 ```typescript
 interface WorkflowConfig {
-  name: string
-  on: WorkflowTriggers
+  name?: string
+  on: WorkflowOn
   env?: Record<string, string>
-  permissions?: WorkflowPermissions
-  concurrency?: WorkflowConcurrency
+  permissions?: Permissions
+  concurrency?: { group: string; 'cancel-in-progress'?: boolean } | string
+  defaults?: { run?: { shell?: string; 'working-directory'?: string } }
 }
 ```
 
@@ -50,8 +51,10 @@ const workflow = new Workflow({
     NODE_ENV: "production",
   },
 })
-  .addJob("test", testJob)
-  .addJob("build", buildJob);
+  .jobs(j => j
+    .add("test", testJob)
+    .add("build", buildJob)
+  );
 
 workflow.build("ci");
 ```
@@ -77,69 +80,156 @@ workflow.build("raw");
 
 ### `Job`
 
-워크플로우의 작업을 나타냅니다. 타입 파라미터 `O`는 `jobOutputs()`를 통한 타입 안전한 job 간 참조를 위해 출력 키를 추적합니다.
+워크플로우의 작업을 나타냅니다. 두 개의 타입 파라미터를 가집니다: `Cx`는 `.steps()`에서 누적된 스텝 출력 컨텍스트를, `O`는 `.outputs()`에서 선언된 출력 키를 추적합니다.
 
 ```typescript
-class Job<O extends Record<string, string> = {}> {
-  constructor(runsOn: string | string[], options?: Partial<JobDefinition>)
-  addStep(step: Step): this
-  needs(jobs: string | string[]): this
-  env(variables: Record<string, string>): this
-  when(condition: string): this
-  permissions(perms: Permissions): this
-  outputs<T extends Record<string, string>>(outputs: T): Job<T>
-  strategy(strategy: JobStrategy): this
-  continueOnError(v: boolean): this
-  timeoutMinutes(m: number): this
+class Job<Cx = {}, O extends Record<string, string> = {}> {
+  constructor(runsOn: string | string[], config?: JobConfig)
+  steps<NewCx>(callback: (s: StepBuilder<{}>) => StepBuilder<NewCx>): Job<NewCx, O>
+  outputs<T extends Record<string, string>>(outputs: T | ((output: Cx) => T)): Job<Cx, T>
   toJSON(): JobDefinition
 }
 ```
 
 | 메서드 | 설명 |
 |--------|------|
-| `addStep(step)` | job에 스텝을 추가합니다. |
-| `needs(jobs)` | job 의존성을 설정합니다. |
-| `env(variables)` | 환경 변수를 설정합니다. |
-| `when(condition)` | job의 `if` 조건을 설정합니다 (예: `"github.ref == 'refs/heads/main'"`). |
-| `permissions(perms)` | job 수준의 권한을 설정합니다 (예: `{ contents: 'read' }`). |
-| `outputs(outputs)` | job 출력을 정의합니다. 출력 키를 캡처한 `Job<T>`를 반환합니다. |
-| `strategy(strategy)` | 매트릭스 전략을 설정합니다. |
-| `continueOnError(v)` | `continue-on-error` 플래그를 설정합니다. |
-| `timeoutMinutes(m)` | `timeout-minutes` 값을 설정합니다. |
+| `steps(callback)` | `StepBuilder` 콜백을 통해 스텝을 정의합니다. 콜백은 빈 `StepBuilder`를 받아 `.add()`로 스텝을 추가한 뒤 반환합니다. |
+| `outputs(outputs)` | job 출력을 정의합니다. 일반 객체 또는 스텝 출력 컨텍스트(`Cx`)를 받는 콜백을 받습니다. |
 | `toJSON()` | `JobDefinition` 객체로 직렬화합니다. |
 
-생성자의 `options` 파라미터로 모든 옵션을 한번에 설정할 수 있습니다:
+#### `JobConfig`
+
+모든 job 설정은 생성자의 `config` 파라미터로 전달합니다:
 
 ```typescript
-const job = new Job("ubuntu-latest", {
-  needs: ["test"],
-  env: { NODE_ENV: "production" },
-  "timeout-minutes": 30,
-});
+interface JobConfig {
+  permissions?: Permissions
+  needs?: string[]
+  strategy?: { matrix?: Record<string, unknown>; 'fail-fast'?: boolean; 'max-parallel'?: number }
+  if?: string
+  environment?: string | { name: string; url?: string }
+  concurrency?: { group: string; 'cancel-in-progress'?: boolean } | string
+  'timeout-minutes'?: number
+  env?: Record<string, string>
+  defaults?: { run?: { shell?: string; 'working-directory'?: string } }
+  services?: Record<string, Service>
+  container?: Container
+  'continue-on-error'?: boolean
+}
 ```
 
 #### 예제
 
 ```typescript
-const job = new Job("ubuntu-latest")
-  .needs(["test"])
-  .env({
-    NODE_ENV: "production",
-  })
-  .when("github.event_name == 'push'")
-  .permissions({ contents: "read" })
-  .strategy({
+const checkout = getAction("actions/checkout@v5");
+
+const job = new Job("ubuntu-latest", {
+  needs: ["test"],
+  env: { NODE_ENV: "production" },
+  if: "github.event_name == 'push'",
+  permissions: { contents: "read" },
+  strategy: {
     matrix: {
       node: ["18", "20", "22"],
     },
-  })
+  },
+  "continue-on-error": false,
+  "timeout-minutes": 30,
+})
+  .steps(s => s
+    .add(checkout({}))
+    .add({ run: "npm test" })
+  )
   .outputs({
     version: "${{ steps.version.outputs.value }}",
-  })
-  .continueOnError(false)
-  .timeoutMinutes(30)
-  .addStep(checkout({}))
-  .addStep({ run: "npm test" });
+  });
+```
+
+---
+
+### `StepBuilder`
+
+`.steps()` 콜백 내에서 스텝을 누적합니다. `.add()` 호출마다 스텝을 추가하고, `id`와 타입이 지정된 출력이 있는 스텝의 경우 출력 컨텍스트 `Cx`를 갱신합니다.
+
+```typescript
+class StepBuilder<Cx = {}> {
+  add<Id extends string, StepO>(step: ActionStep<StepO, Id>): StepBuilder<Cx & Record<Id, StepO>>
+  add(step: JobStep): StepBuilder<Cx>
+  add<Id extends string, StepO>(stepFn: (output: Cx) => ActionStep<StepO, Id>): StepBuilder<Cx & Record<Id, StepO>>
+  add(stepFn: (output: Cx) => JobStep): StepBuilder<Cx>
+}
+```
+
+네 가지 오버로드:
+
+| 오버로드 | 설명 |
+|----------|------|
+| `add(actionStep)` | 타입이 지정된 출력이 있는 `ActionStep`을 추가합니다 (`getAction()`에 `id`를 전달하여 반환). `Cx`에 출력을 병합합니다. |
+| `add(jobStep)` | 일반 `JobStep`을 추가합니다 (run 명령 또는 `id` 없는 액션). `Cx` 변경 없음. |
+| `add(output => actionStep)` | 콜백 형태 — 이전 스텝 출력(`Cx`)을 받아 `ActionStep`을 반환합니다. |
+| `add(output => jobStep)` | 콜백 형태 — 이전 스텝 출력(`Cx`)을 받아 `JobStep`을 반환합니다. |
+
+#### 예제
+
+```typescript
+const checkout = getAction("actions/checkout@v5");
+
+new Job("ubuntu-latest")
+  .steps(s => s
+    .add(checkout({ id: "co" }))
+    .add(output => ({
+      name: "Use ref",
+      run: "echo " + output.co.ref,  // "${{ steps.co.outputs.ref }}"
+    }))
+  );
+```
+
+---
+
+### `JobBuilder`
+
+`.jobs()` 콜백 내에서 job을 누적합니다. `.add()` 호출마다 job을 등록하고, 출력이 선언된 job의 경우 출력 컨텍스트 `Cx`를 갱신합니다.
+
+```typescript
+class JobBuilder<Cx = {}> {
+  add<Id extends string, O extends Record<string, string>>(
+    id: Id, job: Job<any, O>
+  ): JobBuilder<Cx & Record<Id, O>>
+  add(id: string, job: Job | WorkflowCall): JobBuilder<Cx>
+  add<Id extends string, O extends Record<string, string>>(
+    id: Id, jobFn: (output: Cx) => Job<any, O>
+  ): JobBuilder<Cx & Record<Id, O>>
+  add(id: string, jobFn: (output: Cx) => Job | WorkflowCall): JobBuilder<Cx>
+}
+```
+
+네 가지 오버로드:
+
+| 오버로드 | 설명 |
+|----------|------|
+| `add(id, job)` | 출력이 있는 `Job`을 추가합니다. `Cx`에 출력을 병합합니다. |
+| `add(id, job)` | 출력 추적 없이 `Job` 또는 `WorkflowCall`을 추가합니다. |
+| `add(id, output => job)` | 콜백 형태 — 이전 job 출력(`Cx`)을 받아 `Job`을 반환합니다. |
+| `add(id, output => job)` | 콜백 형태 — 이전 job 출력(`Cx`)을 받아 `Job` 또는 `WorkflowCall`을 반환합니다. |
+
+#### 예제
+
+```typescript
+new Workflow({ name: "CI", on: { push: {} } })
+  .jobs(j => j
+    .add("build",
+      new Job("ubuntu-latest")
+        .steps(s => s.add(checkout({ id: "co" })))
+        .outputs(output => ({ ref: output.co.ref }))
+    )
+    .add("deploy", output =>
+      new Job("ubuntu-latest", { needs: ["build"] })
+        .steps(s => s
+          .add({ run: "echo " + output.build.ref })
+        )
+    )
+  )
+  .build("ci");
 ```
 
 ---
@@ -149,33 +239,32 @@ const job = new Job("ubuntu-latest")
 재사용 가능한 [컴포지트 액션](https://docs.github.com/en/actions/sharing-automations/creating-actions/creating-a-composite-action)을 만듭니다.
 
 ```typescript
-class Action {
-  constructor(config: ActionConfig)
-  addStep(step: Step): this
+class Action<Cx = {}> {
+  constructor(config: { name: string; description: string; inputs?: Record<string, unknown>; outputs?: Record<string, unknown> })
+  steps<NewCx>(callback: (s: StepBuilder<{}>) => StepBuilder<NewCx>): Action<NewCx>
+  outputMapping<T extends Record<string, string>>(mapping: (output: Cx) => T): Action<Cx>
   build(filename: string): void
+  toJSON(): object
 }
 ```
 
-#### `ActionConfig`
-
-```typescript
-interface ActionConfig {
-  name: string
-  description: string
-  inputs?: Record<string, ActionInput>
-  outputs?: Record<string, ActionOutput>
-}
-```
+| 메서드 | 설명 |
+|--------|------|
+| `steps(callback)` | `StepBuilder` 콜백을 통해 액션 스텝을 정의합니다. |
+| `outputMapping(fn)` | 스텝 출력을 액션 출력에 매핑합니다. |
+| `build(filename)` | 액션을 `action.yml`로 컴파일합니다. |
 
 #### 예제
 
 ```ts twoslash
-// @noErrors
 // @filename: workflows/example.ts
 // ---cut---
-import { Action } from "../generated/index.js";
+import { Action, getAction } from "../generated/index.js";
 
-const setupEnv = new Action({
+const checkout = getAction("actions/checkout@v5");
+const setupNode = getAction("actions/setup-node@v4");
+
+new Action({
   name: "Setup Environment",
   description: "Setup Node.js and install dependencies",
   inputs: {
@@ -186,17 +275,16 @@ const setupEnv = new Action({
     },
   },
 })
-  .addStep(checkout({}))
-  .addStep(setupNode({
-    with: {
-      "node-version": "${{ inputs.node-version }}",
-    },
-  }))
-  .addStep({
-    run: "npm ci",
-  });
-
-setupEnv.build("setup-env");
+  .steps(s => s
+    .add(checkout({}))
+    .add(setupNode({
+      with: {
+        "node-version": "${{ inputs.node-version }}",
+      },
+    }))
+    .add({ run: "npm ci" })
+  )
+  .build("setup-env");
 ```
 
 생성된 `action.yml`은 다음과 같이 사용할 수 있습니다:
@@ -205,12 +293,12 @@ setupEnv.build("setup-env");
 // 다른 워크플로우에서
 const setupEnv = getAction("./setup-env");
 
-const job = new Job("ubuntu-latest")
-  .addStep(setupEnv({
-    with: {
-      "node-version": "20",
-    },
-  }));
+new Job("ubuntu-latest")
+  .steps(s => s
+    .add(setupEnv({
+      with: { "node-version": "20" },
+    }))
+  );
 ```
 
 ---
@@ -381,34 +469,40 @@ TypeScript 클래스 상속을 통해 재사용 가능한 작업 템플릿을 �
 #### 예제
 
 ```ts twoslash
-// @noErrors
 // @filename: workflows/example.ts
 // ---cut---
-import { Job } from "../generated/index.js";
+import { Job, getAction, Workflow } from "../generated/index.js";
+
+const checkout = getAction("actions/checkout@v5");
+const setupNode = getAction("actions/setup-node@v4");
 
 // 재사용 가능한 작업 템플릿 정의
 class NodeTestJob extends Job {
   constructor(nodeVersion: string) {
     super("ubuntu-latest");
 
-    this
-      .addStep(checkout({}))
-      .addStep(setupNode({
+    this.steps(s => s
+      .add(checkout({}))
+      .add(setupNode({
         with: { "node-version": nodeVersion },
       }))
-      .addStep({ run: "npm ci" })
-      .addStep({ run: "npm test" });
+      .add({ run: "npm ci" })
+      .add({ run: "npm test" })
+    );
   }
 }
 
 // 워크플로우에서 사용
-const workflow = new Workflow({
+new Workflow({
   name: "Test Matrix",
   on: { push: { branches: ["main"] } },
 })
-  .addJob("test-node-18", new NodeTestJob("18"))
-  .addJob("test-node-20", new NodeTestJob("20"))
-  .addJob("test-node-22", new NodeTestJob("22"));
+  .jobs(j => j
+    .add("test-node-18", new NodeTestJob("18"))
+    .add("test-node-20", new NodeTestJob("20"))
+    .add("test-node-22", new NodeTestJob("22"))
+  )
+  .build("test-matrix");
 ```
 
 더 복잡한 재사용 가능한 작업도 만들 수 있습니다:
@@ -416,34 +510,39 @@ const workflow = new Workflow({
 ```typescript
 class DeployJob extends Job {
   constructor(environment: "staging" | "production") {
-    super("ubuntu-latest");
-
-    this
-      .env({
+    super("ubuntu-latest", {
+      env: {
         ENVIRONMENT: environment,
         API_URL: environment === "production"
           ? "https://api.example.com"
           : "https://staging.api.example.com",
-      })
-      .addStep(checkout({}))
-      .addStep(setupNode({ with: { "node-version": "20" } }))
-      .addStep({
+      },
+    });
+
+    this.steps(s => s
+      .add(checkout({}))
+      .add(setupNode({ with: { "node-version": "20" } }))
+      .add({
         name: "Deploy",
         run: `npm run deploy:${environment}`,
         env: {
           DEPLOY_TOKEN: "${{ secrets.DEPLOY_TOKEN }}",
         },
-      });
+      })
+    );
   }
 }
 
 // 워크플로우에서 사용
-const workflow = new Workflow({
+new Workflow({
   name: "Deploy",
   on: { push: { tags: ["v*"] } },
 })
-  .addJob("deploy-staging", new DeployJob("staging"))
-  .addJob("deploy-production", new DeployJob("production").needs(["deploy-staging"]));
+  .jobs(j => j
+    .add("deploy-staging", new DeployJob("staging"))
+    .add("deploy-production", new DeployJob("production"))
+  )
+  .build("deploy");
 ```
 
 ---
@@ -454,23 +553,18 @@ const workflow = new Workflow({
 
 ```typescript
 class WorkflowCall {
-  constructor(uses: string)
-  with(inputs: Record<string, unknown>): this
-  secrets(s: Record<string, unknown> | 'inherit'): this
-  needs(deps: string | string[]): this
-  when(condition: string): this
-  permissions(perms: Permissions): this
+  constructor(uses: string, config?: {
+    with?: Record<string, unknown>
+    secrets?: Record<string, unknown> | 'inherit'
+    needs?: string[]
+    if?: string
+    permissions?: Permissions
+  })
   toJSON(): object
 }
 ```
 
-| 메서드 | 설명 |
-|--------|------|
-| `with(inputs)` | 재사용 워크플로우에 입력값을 전달합니다. |
-| `secrets(s)` | 시크릿을 명시적으로 전달하거나, `'inherit'`로 모든 시크릿을 전달합니다. |
-| `needs(deps)` | job 의존성을 설정합니다. |
-| `when(condition)` | job의 `if` 조건을 설정합니다. |
-| `permissions(perms)` | job 수준의 권한을 설정합니다. |
+모든 옵션은 생성자의 `config` 파라미터로 전달합니다.
 
 #### 예제
 
@@ -479,18 +573,23 @@ class WorkflowCall {
 // ---cut---
 import { WorkflowCall, Workflow } from "../generated/index.js";
 
-const deploy = new WorkflowCall("octo-org/deploy/.github/workflows/deploy.yml@main")
-  .with({ environment: "production" })
-  .secrets("inherit")
-  .needs(["build"]);
+const deploy = new WorkflowCall(
+  "octo-org/deploy/.github/workflows/deploy.yml@main",
+  {
+    with: { environment: "production" },
+    secrets: "inherit",
+    needs: ["build"],
+  },
+);
 
-const workflow = new Workflow({
+new Workflow({
   name: "Release",
   on: { push: { tags: ["v*"] } },
 })
-  .addJob("deploy", deploy);
-
-workflow.build("release");
+  .jobs(j => j
+    .add("deploy", deploy)
+  )
+  .build("release");
 ```
 
 생성되는 YAML:
@@ -537,11 +636,13 @@ const setupEnv = new Action({
 });
 setupEnv.build("setup-env");
 
-const job = new Job("ubuntu-latest")
-  .addStep({
-    ...ActionRef.from(setupEnv).toJSON(),
-    with: { "node-version": "20" },
-  });
+new Job("ubuntu-latest")
+  .steps(s => s
+    .add({
+      ...ActionRef.from(setupEnv).toJSON(),
+      with: { "node-version": "20" },
+    })
+  );
 ```
 
 ---
@@ -577,7 +678,6 @@ function getAction<T extends string>(ref: T): {
 
 ```typescript
 const checkout = getAction("actions/checkout@v5");
-const setupNode = getAction("actions/setup-node@v4");
 
 // 완전한 타입 안전성으로 사용
 const step = checkout({
@@ -593,7 +693,7 @@ const checkoutStep = checkout({ id: "my-checkout" });
 // checkoutStep.outputs.ref → "${{ steps.my-checkout.outputs.ref }}"
 ```
 
-`jobOutputs()`를 활용한 전체 typed outputs 예제는 [워크플로우 작성의 출력 섹션](../guide/writing-workflows.md#출력)을 참조하세요.
+전체 typed outputs 예제는 [워크플로우 작성의 출력 섹션](../guide/writing-workflows.md#출력)을 참조하세요.
 
 ---
 
@@ -601,10 +701,12 @@ const checkoutStep = checkout({ id: "my-checkout" });
 
 다운스트림 job에서 사용할 타입이 지정된 job 출력 참조를 생성합니다. `Job` 객체의 `.outputs()` 호출에서 출력 키를 읽어 <code v-pre>${{ needs.&lt;jobId&gt;.outputs.&lt;key&gt; }}</code> 표현식을 생성합니다.
 
+이 함수는 호환성 헬퍼입니다. 기본 패턴은 `.jobs()` 콜백을 사용하는 것이며, 여기서 job 출력 컨텍스트가 자동으로 전달됩니다.
+
 ```typescript
 function jobOutputs<O extends Record<string, string>>(
   jobId: string,
-  job: Job<O>,
+  job: Job<any, O>,
 ): JobOutputs<O>
 ```
 
@@ -617,6 +719,54 @@ const buildOutputs = jobOutputs("build", build);
 ```
 
 전체 예제는 [워크플로우 작성의 출력 섹션](../guide/writing-workflows.md#출력)을 참조하세요.
+
+---
+
+### `defineConfig()`
+
+`gaji.config.ts`용 타입 안전한 설정 헬퍼입니다.
+
+```typescript
+function defineConfig(config: GajiConfig): GajiConfig
+```
+
+#### `GajiConfig`
+
+```typescript
+interface GajiConfig {
+  workflows?: string        // 기본값: "workflows"
+  output?: string           // 기본값: ".github"
+  generated?: string        // 기본값: "generated"
+  watch?: {
+    debounce?: number       // 기본값: 300 (ms)
+    ignore?: string[]       // 기본값: ["node_modules", ".git", "generated"]
+  }
+  build?: {
+    validate?: boolean      // 기본값: true
+    format?: boolean        // 기본값: true
+    cacheTtlDays?: number   // 기본값: 30
+  }
+  github?: {
+    token?: string
+    apiUrl?: string         // GitHub Enterprise용
+  }
+}
+```
+
+#### 예제
+
+```typescript
+// gaji.config.ts
+import { defineConfig } from "./generated/index.js";
+
+export default defineConfig({
+  workflows: "workflows",
+  output: ".github",
+  build: {
+    cacheTtlDays: 14,
+  },
+});
+```
 
 ---
 
@@ -647,8 +797,9 @@ interface JobStep {
 `id`를 제공했을 때 `getAction()`이 반환하는 스텝입니다. `JobStep`을 확장하여 타입이 지정된 출력 접근을 제공합니다.
 
 ```typescript
-interface ActionStep<O = {}> extends JobStep {
+interface ActionStep<O = {}, Id extends string = string> extends JobStep {
   readonly outputs: O
+  readonly id: Id
 }
 ```
 
@@ -748,36 +899,42 @@ interface ActionOutput {
 
 ### 완전한 워크플로우
 
-```typescript
+```ts twoslash
+// @filename: workflows/example.ts
+// ---cut---
 import { getAction, Job, Workflow } from "../generated/index.js";
 
 const checkout = getAction("actions/checkout@v5");
 const setupNode = getAction("actions/setup-node@v4");
 
-const test = new Job("ubuntu-latest")
-  .addStep(checkout({}))
-  .addStep(setupNode({ with: { "node-version": "20" } }))
-  .addStep({ run: "npm ci" })
-  .addStep({ run: "npm test" });
-
-const build = new Job("ubuntu-latest")
-  .needs(["test"])
-  .addStep(checkout({}))
-  .addStep(setupNode({ with: { "node-version": "20" } }))
-  .addStep({ run: "npm ci" })
-  .addStep({ run: "npm run build" });
-
-const workflow = new Workflow({
+new Workflow({
   name: "CI",
   on: {
     push: { branches: ["main"] },
     pull_request: { branches: ["main"] },
   },
 })
-  .addJob("test", test)
-  .addJob("build", build);
-
-workflow.build("ci");
+  .jobs(j => j
+    .add("test",
+      new Job("ubuntu-latest")
+        .steps(s => s
+          .add(checkout({}))
+          .add(setupNode({ with: { "node-version": "20" } }))
+          .add({ run: "npm ci" })
+          .add({ run: "npm test" })
+        )
+    )
+    .add("build",
+      new Job("ubuntu-latest", { needs: ["test"] })
+        .steps(s => s
+          .add(checkout({}))
+          .add(setupNode({ with: { "node-version": "20" } }))
+          .add({ run: "npm ci" })
+          .add({ run: "npm run build" })
+        )
+    )
+  )
+  .build("ci");
 ```
 
 ## 다음 단계

--- a/docs/reference/actions.md
+++ b/docs/reference/actions.md
@@ -26,12 +26,14 @@ const setupNode = getAction("actions/setup-node@v4");
 
 // Use in workflow
 const job = new Job("ubuntu-latest")
-  .addStep(checkout({}))
-  .addStep(setupNode({
-    with: {
-      "node-version": "20",  // ✅ Type-safe!
-    },
-  }));
+  .steps(s => s
+    .add(checkout({}))
+    .add(setupNode({
+      with: {
+        "node-version": "20",  // ✅ Type-safe!
+      },
+    }))
+  );
 ```
 
 ## Action Reference Format
@@ -120,10 +122,10 @@ gaji add actions/checkout@v5
 const checkout = getAction("actions/checkout@v5");
 
 // Basic usage
-.addStep(checkout({}))
+.add(checkout({}))
 
 // With options
-.addStep(checkout({
+.add(checkout({
   with: {
     repository: "owner/repo",
     ref: "main",
@@ -144,7 +146,7 @@ gaji add actions/setup-node@v4
 ```typescript
 const setupNode = getAction("actions/setup-node@v4");
 
-.addStep(setupNode({
+.add(setupNode({
   with: {
     "node-version": "20",
     cache: "npm",
@@ -163,7 +165,7 @@ gaji add actions/cache@v4
 ```typescript
 const cache = getAction("actions/cache@v4");
 
-.addStep(cache({
+.add(cache({
   with: {
     path: "node_modules",
     key: "${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}",
@@ -183,7 +185,7 @@ gaji add actions/upload-artifact@v4
 ```typescript
 const uploadArtifact = getAction("actions/upload-artifact@v4");
 
-.addStep(uploadArtifact({
+.add(uploadArtifact({
   with: {
     name: "build-output",
     path: "dist/",
@@ -202,7 +204,7 @@ gaji add actions/download-artifact@v4
 ```typescript
 const downloadArtifact = getAction("actions/download-artifact@v4");
 
-.addStep(downloadArtifact({
+.add(downloadArtifact({
   with: {
     name: "build-output",
     path: "dist/",
@@ -233,15 +235,17 @@ const setupBuildx = getAction("docker/setup-buildx-action@v3");
 const buildPush = getAction("docker/build-push-action@v5");
 
 const job = new Job("ubuntu-latest")
-  .addStep(checkout({}))
-  .addStep(setupBuildx({}))
-  .addStep(buildPush({
-    with: {
-      context: ".",
-      push: true,
-      tags: "user/app:latest",
-    },
-  }));
+  .steps(s => s
+    .add(checkout({}))
+    .add(setupBuildx({}))
+    .add(buildPush({
+      with: {
+        context: ".",
+        push: true,
+        tags: "user/app:latest",
+      },
+    }))
+  );
 ```
 
 ## Local Actions
@@ -251,7 +255,7 @@ Reference local composite actions:
 ```typescript
 const myAction = getAction("./my-action");
 
-.addStep(myAction({
+.add(myAction({
   with: {
     input: "value",
   },

--- a/src/init/mod.rs
+++ b/src/init/mod.rs
@@ -336,13 +336,14 @@ fn create_config(root: &Path) -> Result<()> {
         println!("{} gaji.config.ts already exists", "⏭️ ".dimmed());
         return Ok(());
     }
-    // Check for legacy .gaji.toml
+    // Check for legacy .gaji.toml and migrate
     let legacy_path = root.join(".gaji.toml");
     if legacy_path.exists() {
         println!(
-            "{} .gaji.toml found — consider migrating to gaji.config.ts",
-            "⚠️ ".yellow()
+            "{} .gaji.toml found — migrating to gaji.config.ts",
+            "🔄".cyan()
         );
+        migration::migrate_toml_config(root)?;
         return Ok(());
     }
     std::fs::write(&config_path, templates::GAJI_CONFIG_TEMPLATE)?;


### PR DESCRIPTION
## Summary

- Add TOML → TS config migration and fix migration codegen to emit the new callback builder API
- Rewrite all documentation (English + Korean) to use `.steps(s => s.add(...))` / `.jobs(j => j.add(...))` / constructor-only `JobConfig`
- Add config tests (env var precedence, integration pipeline)

## Changes

- `src/init/migration.rs`: Fix codegen to emit `.steps(s => s.add(...))` / `.jobs(j => j.add(...))` instead of `.addStep()` / `.addJob()`. Add `migrate_toml_config()` for `.gaji.toml` → `gaji.config.ts` conversion.
- `src/init/mod.rs`: Call TOML migration when `.gaji.toml` detected during `gaji init`
- `src/config.rs`: Add env var precedence test
- `tests/integration.rs`: Add `gaji.config.ts` pipeline integration test
- `docs/reference/api.md`: Full rewrite — `StepBuilder`/`JobBuilder` sections, constructor-only `JobConfig`, `defineConfig`/`GajiConfig`
- `docs/guide/writing-workflows.md`: Full rewrite with callback builder API throughout
- `docs/guide/migration.md`: Add "Configuration Migration" section, update all code examples
- `docs/examples/*.md`: Update all code examples (simple-ci, matrix-build, composite-action, javascript-action)
- `docs/reference/actions.md`, `docs/guide/why.md`: Update code snippets
- `docs/ko/**`: Mirror all English changes to Korean translations
- `ROADMAP.md`: Mark Phase 4 as complete

## Related Issues

Part of gaji 1.0 plan (ROADMAP.md Phase 4)

## Checklist

- [x] `cargo test --all-features` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all --check` passes
- [x] Updated documentation if needed
- [x] Added tests for new functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)