### PR TITLE
chore: release v1.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0](https://github.com/dodok8/gaji/compare/v0.6.0...v1.0.0) - 2026-02-22
+
+### Other
+
+- gaji 1.0.0 — callback builder API and TypeScript config ([#68](https://github.com/dodok8/gaji/pull/68))
+
 ## [0.6.0](https://github.com/dodok8/gaji/compare/v0.5.1...v0.6.0) - 2026-02-20
 
 ### Added


### PR DESCRIPTION



## 🤖 New release

* `gaji`: 0.6.0 -> 1.0.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.0.0](https://github.com/dodok8/gaji/compare/v0.6.0...v1.0.0) - 2026-02-22

### Other

- gaji 1.0.0 — callback builder API and TypeScript config ([#68](https://github.com/dodok8/gaji/pull/68))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).