### PR TITLE
chore: release v1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0](https://github.com/dodok8/gaji/compare/v1.0.0...v1.1.0) - 2026-02-23
+
+### Added
+
+- handle duplicated jobId ([#73](https://github.com/dodok8/gaji/pull/73))
+
+### Other
+
+- release v1.0.0 ([#69](https://github.com/dodok8/gaji/pull/69))
+
 ## [1.0.0](https://github.com/dodok8/gaji/compare/v0.6.0...v1.0.0) - 2026-02-22
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -650,7 +650,7 @@ dependencies = [
 
 [[package]]
 name = "gaji"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gaji"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2021"
 description = "Type-safe GitHub Actions workflows in TypeScript"
 license = "MIT"


### PR DESCRIPTION



## 🤖 New release

* `gaji`: 1.0.0 -> 1.1.0 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [1.1.0](https://github.com/dodok8/gaji/compare/v1.0.0...v1.1.0) - 2026-02-23

### Added

- handle duplicated jobId ([#73](https://github.com/dodok8/gaji/pull/73))

### Other

- release v1.0.0 ([#69](https://github.com/dodok8/gaji/pull/69))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).