### PR TITLE
Fallback to npx wrapper script on windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 - Automatic type generation from `action.yml` files
 - Composite action and reusable workflow support
 - File watching for development (`--watch`)
-- Built-in QuickJS execution with `npx tsx` fallback
+- Built-in QuickJS execution with `npx tsx` fallback (on Windows, probes `npx.ps1` and `npx.cmd` if `npx` is not found)
 - GitHub Enterprise support
 - Single binary distribution (Rust)
 

--- a/docs/ko/reference/cli.md
+++ b/docs/ko/reference/cli.md
@@ -132,7 +132,7 @@ gaji build -i workflows/ci.ts workflows/release.ts
 **동작.**
 
 - 지정된 경로의 모든 `.ts` 파일 찾기
-- 내장 QuickJS 엔진으로 실행 (`npx tsx` 폴백)
+- 내장 QuickJS 엔진으로 실행 (`npx tsx` 폴백; Windows에서는 `npx`를 찾지 못하면 `npx.ps1`, `npx.cmd` 순으로 탐색)
 - 출력을 YAML로 변환
 - 워크플로우를 `.github/workflows/`에 작성
 - 컴포지트 액션을 `.github/actions/<이름>/action.yml`에 작성

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -132,7 +132,7 @@ Validation and formatting options are configured via `.gaji.toml`, not CLI flags
 **What it does.**
 
 - Finds all `.ts` files in the specified paths
-- Executes them with the built-in QuickJS engine (falls back to `npx tsx`)
+- Executes them with the built-in QuickJS engine (falls back to `npx tsx`; on Windows, probes `npx.ps1` and `npx.cmd` if `npx` is not found)
 - Converts output to YAML
 - Writes workflows to `.github/workflows/`
 - Writes composite actions to `.github/actions/<name>/action.yml`

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,3 +1,5 @@
+#[cfg(windows)]
+use std::cell::OnceCell;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -270,9 +272,28 @@ impl WorkflowBuilder {
     }
 }
 
-/// Execute a workflow file using npx tsx (fallback strategy)
+#[cfg(not(windows))]
+fn get_npx() -> Result<&'static str> {
+    Ok("npx")
+}
+
+#[cfg(windows)]
+fn get_npx() -> Result<&'static str> {
+    std::thread_local! {
+        static NPX: OnceCell<Option<&'static str>> = const { OnceCell::new() };
+    }
+    NPX.with(|npx| {
+        *npx.get_or_init(|| {
+            ["npx", "npx.ps1", "npx.cmd"]
+                .into_iter()
+                .find(|candidate| Command::new(candidate).arg("--version").output().is_ok())
+        })
+    })
+    .context("Failed to find npx")
+}
+
 fn execute_workflow_npx(workflow_path: &Path) -> Result<String> {
-    let output = Command::new("npx")
+    let output = Command::new(get_npx()?)
         .args(["tsx", workflow_path.to_str().unwrap()])
         .output();
 
@@ -284,7 +305,7 @@ fn execute_workflow_npx(workflow_path: &Path) -> Result<String> {
         }
         Err(_) => {
             // Try ts-node as fallback
-            let output = Command::new("npx")
+            let output = Command::new(get_npx()?)
                 .args(["ts-node", workflow_path.to_str().unwrap()])
                 .output()
                 .context("Neither tsx nor ts-node is available")?;


### PR DESCRIPTION
## Summary

On Windows, `npx` may not be invocable directly — only `npx.ps1` or `npx.cmd` may be on PATH. This PR probes all three in order on Windows and caches the result. Non-Windows uses `"npx"` as a compile-time constant.

## Changes

- `src/builder.rs`: Added `#[cfg(windows)]` / `#[cfg(not(windows))]` `get_npx()` helper; refactored `execute_workflow_npx` to use it
- `README.md`, `docs/reference/cli.md`, `docs/ko/reference/cli.md`: Note Windows fallback behavior

## Related Issues

Fixes #74

## Checklist

- [x] `cargo test --all-features` passes
- [x] `cargo clippy --all-targets --all-features -- -D warnings` passes
- [x] `cargo fmt --all --check` passes
- [x] Updated documentation if needed
- [ ] Added tests for new functionality